### PR TITLE
feat: RequestIdMiddleware を実装する (#21)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -12,7 +12,7 @@ from nene2.database import (
     SqlAlchemyQueryExecutor,
 )
 from nene2.http import HealthStatus
-from nene2.middleware import ErrorHandlerMiddleware, SecurityHeadersMiddleware
+from nene2.middleware import ErrorHandlerMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware
 from nene2.validation.exceptions import ValidationException
 
 from .note.exceptions import NoteNotFoundExceptionHandler
@@ -67,6 +67,7 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    app.add_middleware(RequestIdMiddleware)
     if cfg.security_headers_enabled:
         app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -2,6 +2,13 @@
 
 from .domain_exception import DomainExceptionHandlerProtocol
 from .error_handler import ErrorHandlerMiddleware
+from .request_id import RequestIdMiddleware, request_id_var
 from .security_headers import SecurityHeadersMiddleware
 
-__all__ = ["DomainExceptionHandlerProtocol", "ErrorHandlerMiddleware", "SecurityHeadersMiddleware"]
+__all__ = [
+    "DomainExceptionHandlerProtocol",
+    "ErrorHandlerMiddleware",
+    "RequestIdMiddleware",
+    "SecurityHeadersMiddleware",
+    "request_id_var",
+]

--- a/src/nene2/middleware/request_id.py
+++ b/src/nene2/middleware/request_id.py
@@ -1,0 +1,27 @@
+"""Request ID middleware.
+
+Attaches a UUID v4 X-Request-Id to every request/response.
+Uses contextvars so downstream code (e.g. structlog) can read the ID.
+"""
+
+import uuid
+from contextvars import ContextVar
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_REQUEST_ID_HEADER = "X-Request-Id"
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Generate or forward X-Request-Id and expose it via contextvars."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = request.headers.get(_REQUEST_ID_HEADER) or str(uuid.uuid4())
+        request_id_var.set(request_id)
+        response = await call_next(request)
+        response.headers[_REQUEST_ID_HEADER] = request_id
+        return response

--- a/tests/nene2/middleware/test_request_id.py
+++ b/tests/nene2/middleware/test_request_id.py
@@ -1,0 +1,46 @@
+"""Tests for RequestIdMiddleware."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.middleware import RequestIdMiddleware, request_id_var
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"request_id": request_id_var.get()})
+
+    return app
+
+
+def test_response_has_x_request_id() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert "X-Request-Id" in response.headers
+    rid = response.headers["X-Request-Id"]
+    assert len(rid) == 36  # UUID v4 format
+
+
+def test_forwards_provided_request_id() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/ping", headers={"X-Request-Id": "my-trace-id-123"})
+    assert response.headers["X-Request-Id"] == "my-trace-id-123"
+
+
+def test_request_id_available_in_contextvars() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/ping")
+    body = response.json()
+    assert body["request_id"] == response.headers["X-Request-Id"]
+
+
+def test_each_request_gets_unique_id() -> None:
+    client = TestClient(_make_app())
+    ids = {client.get("/ping").headers["X-Request-Id"] for _ in range(5)}
+    assert len(ids) == 5


### PR DESCRIPTION
## Summary
- `RequestIdMiddleware` を新規実装 (`src/nene2/middleware/request_id.py`)
- リクエストヘッダーに `X-Request-Id` があればそれを使い、なければ UUID v4 を生成してレスポンスに付与
- `request_id_var` (ContextVar) で下流コード (structlog など) から参照可能
- `src/example/app.py` に組み込み

Closes #21

## Test plan
- [x] 77 tests pass (coverage 93%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)