### PR TITLE
feat: structlog セットアップと RequestLoggingMiddleware を実装する (#22)

### DIFF
--- a/docs/adr/0005-logging.md
+++ b/docs/adr/0005-logging.md
@@ -1,0 +1,24 @@
+# ADR-0005 — Logging: structlog with JSON output
+
+Date: 2026-05-19  
+Status: Accepted
+
+## Context
+
+We need structured, machine-readable logs for production observability. Python's stdlib `logging` is text-oriented and composing contextual fields (request_id, user_id) requires thread-locals or manual key passing. PHP NENE2 uses Monolog with JSON formatter.
+
+## Decision
+
+- **structlog ≥ 24.0** as the logging library
+- `setup_logging(app_env)` configures stdlib root logger to route through structlog
+- `app_env == "local"` → ConsoleRenderer (colored, human-readable)
+- `app_env != "local"` → JSONRenderer (one JSON object per line, machine-readable)
+- Contextual fields (request_id, method, path, status_code, duration_ms) bound via `structlog.contextvars` — no arguments passed between functions
+- `RequestLoggingMiddleware` clears and rebinds context per request
+- `print()` is forbidden (ruff T20 rule); use `structlog.get_logger(__name__).info(...)` instead
+
+## Consequences
+
+- Log lines in production are valid JSON — parseable by Datadog, Loki, CloudWatch without config
+- Request ID automatically appears in all log lines emitted during a request (via contextvars)
+- `setup_logging()` must be called once at app startup; tests do not call it (stdlib logging captures output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-multipart>=0.0.12",
     "sqlalchemy>=2.0.49",
     "alembic>=1.18.4",
+    "structlog>=24.0",
 ]
 
 [project.optional-dependencies]

--- a/src/example/app.py
+++ b/src/example/app.py
@@ -12,7 +12,13 @@ from nene2.database import (
     SqlAlchemyQueryExecutor,
 )
 from nene2.http import HealthStatus
-from nene2.middleware import ErrorHandlerMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware
+from nene2.log import setup_logging
+from nene2.middleware import (
+    ErrorHandlerMiddleware,
+    RequestIdMiddleware,
+    RequestLoggingMiddleware,
+    SecurityHeadersMiddleware,
+)
 from nene2.validation.exceptions import ValidationException
 
 from .note.exceptions import NoteNotFoundExceptionHandler
@@ -59,6 +65,7 @@ def _build_repositories(
 
 def create_app(settings: AppSettings | None = None) -> FastAPI:
     cfg = settings or AppSettings()
+    setup_logging(cfg.app_env)
 
     app = FastAPI(
         title=cfg.app_name,
@@ -67,6 +74,7 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(RequestIdMiddleware)
     if cfg.security_headers_enabled:
         app.add_middleware(SecurityHeadersMiddleware)

--- a/src/nene2/log/__init__.py
+++ b/src/nene2/log/__init__.py
@@ -1,0 +1,5 @@
+"""NENE2 structured logging setup (structlog)."""
+
+from .setup import setup_logging
+
+__all__ = ["setup_logging"]

--- a/src/nene2/log/setup.py
+++ b/src/nene2/log/setup.py
@@ -1,0 +1,49 @@
+"""Configure structlog for the application.
+
+Call setup_logging() once at startup (in create_app).
+- production / test: JSON renderer
+- local (development): ConsoleRenderer with colors
+"""
+
+import logging
+import sys
+
+import structlog
+
+
+def setup_logging(app_env: str = "local") -> None:
+    shared_processors: list[structlog.types.Processor] = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+    if app_env == "local":
+        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer()
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processor=renderer,
+        foreign_pre_chain=shared_processors,
+    )
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -3,12 +3,14 @@
 from .domain_exception import DomainExceptionHandlerProtocol
 from .error_handler import ErrorHandlerMiddleware
 from .request_id import RequestIdMiddleware, request_id_var
+from .request_logging import RequestLoggingMiddleware
 from .security_headers import SecurityHeadersMiddleware
 
 __all__ = [
     "DomainExceptionHandlerProtocol",
     "ErrorHandlerMiddleware",
     "RequestIdMiddleware",
+    "RequestLoggingMiddleware",
     "SecurityHeadersMiddleware",
     "request_id_var",
 ]

--- a/src/nene2/middleware/request_logging.py
+++ b/src/nene2/middleware/request_logging.py
@@ -1,0 +1,34 @@
+"""Request logging middleware using structlog."""
+
+import time
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from .request_id import request_id_var
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log each request and response with method, path, status, and duration."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        start = time.perf_counter()
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id_var.get(),
+            method=request.method,
+            path=request.url.path,
+        )
+        logger.info("request.received")
+        response = await call_next(request)
+        duration_ms = round((time.perf_counter() - start) * 1000, 1)
+        structlog.contextvars.bind_contextvars(
+            status_code=response.status_code,
+            duration_ms=duration_ms,
+        )
+        logger.info("request.completed")
+        return response

--- a/tests/nene2/middleware/test_request_logging.py
+++ b/tests/nene2/middleware/test_request_logging.py
@@ -1,0 +1,41 @@
+"""Tests for RequestLoggingMiddleware."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.middleware import RequestIdMiddleware, RequestLoggingMiddleware
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/fail")
+    async def fail() -> JSONResponse:
+        return JSONResponse({}, status_code=500)
+
+    return app
+
+
+def test_request_passes_through() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/ping")
+    assert response.status_code == 200
+
+
+def test_error_response_passes_through() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/fail")
+    assert response.status_code == 500
+
+
+def test_logging_does_not_remove_headers() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/ping")
+    assert "X-Request-Id" in response.headers

--- a/uv.lock
+++ b/uv.lock
@@ -754,6 +754,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
+    { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -794,6 +795,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
+    { name = "structlog", specifier = ">=24.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 provides-extras = ["dev"]
@@ -1269,6 +1271,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `structlog>=24.0` を依存に追加
- `src/nene2/log/setup.py` — `setup_logging(app_env)` でJSON/Console形式を切り替え
- `RequestLoggingMiddleware` — method, path, status_code, duration_ms を構造化ログ出力
- `request_id_var` (contextvars) 経由でRequest IDをすべてのログに自動付与
- `src/example/app.py` に組み込み
- ADR-0005: ロギング方針

Closes #22

## Test plan
- [x] 80 tests pass (coverage 93%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)