### PR TITLE
feat: RequestSizeLimitMiddleware を実装する (#23)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -17,6 +17,7 @@ from nene2.middleware import (
     ErrorHandlerMiddleware,
     RequestIdMiddleware,
     RequestLoggingMiddleware,
+    RequestSizeLimitMiddleware,
     SecurityHeadersMiddleware,
 )
 from nene2.validation.exceptions import ValidationException
@@ -74,6 +75,7 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    app.add_middleware(RequestSizeLimitMiddleware, max_bytes=cfg.max_body_size)
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(RequestIdMiddleware)
     if cfg.security_headers_enabled:

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -13,6 +13,7 @@ class AppSettings(BaseSettings):
     app_debug: bool = False
     app_name: str = "nene2-python"
     security_headers_enabled: bool = True
+    max_body_size: int = 1_048_576  # 1 MiB
 
     db_adapter: str = "sqlite"
     db_name: str = ":memory:"

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -4,6 +4,7 @@ from .domain_exception import DomainExceptionHandlerProtocol
 from .error_handler import ErrorHandlerMiddleware
 from .request_id import RequestIdMiddleware, request_id_var
 from .request_logging import RequestLoggingMiddleware
+from .request_size_limit import RequestSizeLimitMiddleware
 from .security_headers import SecurityHeadersMiddleware
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "ErrorHandlerMiddleware",
     "RequestIdMiddleware",
     "RequestLoggingMiddleware",
+    "RequestSizeLimitMiddleware",
     "SecurityHeadersMiddleware",
     "request_id_var",
 ]

--- a/src/nene2/middleware/request_size_limit.py
+++ b/src/nene2/middleware/request_size_limit.py
@@ -1,0 +1,32 @@
+"""Request body size limit middleware.
+
+Rejects requests whose Content-Length exceeds the configured maximum.
+Protects against memory exhaustion from oversized payloads.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
+
+_DEFAULT_MAX_BYTES = 1_048_576  # 1 MiB
+
+
+class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose Content-Length exceeds max_bytes."""
+
+    def __init__(self, app: object, *, max_bytes: int = _DEFAULT_MAX_BYTES) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        content_length = request.headers.get("Content-Length")
+        if content_length is not None and int(content_length) > self._max_bytes:
+            return problem_details_response(
+                "payload-too-large",
+                "Payload Too Large",
+                413,
+                f"Request body must not exceed {self._max_bytes} bytes.",
+            )
+        return await call_next(request)

--- a/tests/nene2/middleware/test_request_size_limit.py
+++ b/tests/nene2/middleware/test_request_size_limit.py
@@ -1,0 +1,46 @@
+"""Tests for RequestSizeLimitMiddleware."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.middleware import RequestSizeLimitMiddleware
+
+
+def _make_app(max_bytes: int = 100) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestSizeLimitMiddleware, max_bytes=max_bytes)
+
+    @app.post("/upload")
+    async def upload() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return app
+
+
+def test_small_request_passes() -> None:
+    client = TestClient(_make_app(max_bytes=1000))
+    response = client.post(
+        "/upload",
+        content=b"x" * 50,
+        headers={"Content-Length": "50", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 200
+
+
+def test_oversized_request_returns_413() -> None:
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"x" * 200,
+        headers={"Content-Length": "200", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 413
+    body = response.json()
+    assert body["type"].endswith("payload-too-large")
+
+
+def test_no_content_length_passes() -> None:
+    client = TestClient(_make_app(max_bytes=10_000))
+    response = client.post("/upload", json={"data": "small"})
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- `RequestSizeLimitMiddleware` を新規実装 (`src/nene2/middleware/request_size_limit.py`)
- Content-Length ヘッダーで上限チェック、超過時に 413 Problem Details を返す
- `AppSettings.max_body_size` (デフォルト 1MiB) で閾値を設定
- `src/example/app.py` に組み込み

Closes #23

## Test plan
- [x] 83 tests pass (coverage 93%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)