### PR TITLE
feat: ThrottleMiddleware（固定ウィンドウ レート制限）を実装する (#24)

### DIFF
--- a/docs/adr/0006-rate-limiting.md
+++ b/docs/adr/0006-rate-limiting.md
@@ -1,0 +1,22 @@
+# ADR-0006 — Rate Limiting: Fixed Window, In-Memory
+
+Date: 2026-05-19  
+Status: Accepted
+
+## Context
+
+We need to protect endpoints from abuse and runaway clients. PHP NENE2's `ThrottleMiddleware` uses a fixed-window strategy stored in PHP session / APCu. For Python we need a simple default with a clear upgrade path.
+
+## Decision
+
+- **Fixed-window algorithm**: count requests per IP per time window (default: 60 req / 60 s)
+- **Storage**: in-process `dict` protected by `threading.Lock` — zero dependencies, zero config
+- **Key**: `X-Forwarded-For` first entry (when present) else `request.client.host`
+- **429 response**: RFC 9457 Problem Details with `Retry-After` header (seconds until window resets)
+- **Disabled by default in tests**: `AppSettings(throttle_enabled=False)` — tests create isolated apps with explicit `ThrottleMiddleware(limit=N)`
+
+## Consequences
+
+- Suitable for single-process deployments (uvicorn workers share no state between processes)
+- For multi-process / multi-node deployments, replace the in-memory store with Redis (implement `ThrottleStoreInterface` — future work)
+- Fixed-window is vulnerable to burst at window boundary; sliding-log or token-bucket can be added later without changing the interface

--- a/src/example/app.py
+++ b/src/example/app.py
@@ -19,6 +19,7 @@ from nene2.middleware import (
     RequestLoggingMiddleware,
     RequestSizeLimitMiddleware,
     SecurityHeadersMiddleware,
+    ThrottleMiddleware,
 )
 from nene2.validation.exceptions import ValidationException
 
@@ -75,6 +76,12 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    if cfg.throttle_enabled:
+        app.add_middleware(
+            ThrottleMiddleware,
+            limit=cfg.throttle_limit,
+            window=cfg.throttle_window,
+        )
     app.add_middleware(RequestSizeLimitMiddleware, max_bytes=cfg.max_body_size)
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(RequestIdMiddleware)

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -14,6 +14,9 @@ class AppSettings(BaseSettings):
     app_name: str = "nene2-python"
     security_headers_enabled: bool = True
     max_body_size: int = 1_048_576  # 1 MiB
+    throttle_enabled: bool = True
+    throttle_limit: int = 60
+    throttle_window: int = 60  # seconds
 
     db_adapter: str = "sqlite"
     db_name: str = ":memory:"

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -6,6 +6,7 @@ from .request_id import RequestIdMiddleware, request_id_var
 from .request_logging import RequestLoggingMiddleware
 from .request_size_limit import RequestSizeLimitMiddleware
 from .security_headers import SecurityHeadersMiddleware
+from .throttle import ThrottleMiddleware
 
 __all__ = [
     "DomainExceptionHandlerProtocol",
@@ -14,5 +15,6 @@ __all__ = [
     "RequestLoggingMiddleware",
     "RequestSizeLimitMiddleware",
     "SecurityHeadersMiddleware",
+    "ThrottleMiddleware",
     "request_id_var",
 ]

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -1,0 +1,65 @@
+"""Fixed-window rate limiting middleware.
+
+Tracks request counts per client IP in an in-memory dict.
+Exceeding the limit returns 429 with a Retry-After header.
+"""
+
+import threading
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
+
+_DEFAULT_LIMIT = 60
+_DEFAULT_WINDOW = 60  # seconds
+
+
+class ThrottleMiddleware(BaseHTTPMiddleware):
+    """Fixed-window rate limiter keyed by client IP."""
+
+    def __init__(
+        self,
+        app: object,
+        *,
+        limit: int = _DEFAULT_LIMIT,
+        window: int = _DEFAULT_WINDOW,
+    ) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._limit = limit
+        self._window = window
+        self._counts: dict[str, tuple[int, float]] = {}
+        self._lock = threading.Lock()
+
+    def _client_key(self, request: Request) -> str:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+        return request.client.host if request.client else "unknown"
+
+    def _is_allowed(self, key: str) -> tuple[bool, int]:
+        now = time.monotonic()
+        with self._lock:
+            count, window_start = self._counts.get(key, (0, now))
+            if now - window_start >= self._window:
+                count, window_start = 0, now
+            count += 1
+            self._counts[key] = (count, window_start)
+            remaining = max(0, self._window - int(now - window_start))
+        return count <= self._limit, remaining
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        key = self._client_key(request)
+        allowed, retry_after = self._is_allowed(key)
+        if not allowed:
+            response = problem_details_response(
+                "too-many-requests",
+                "Too Many Requests",
+                429,
+                f"Rate limit exceeded. Retry after {retry_after} seconds.",
+            )
+            response.headers["Retry-After"] = str(retry_after)
+            return response
+        return await call_next(request)

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -1,0 +1,45 @@
+"""Tests for ThrottleMiddleware."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.middleware import ThrottleMiddleware
+
+
+def _make_app(limit: int = 3, window: int = 60) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(ThrottleMiddleware, limit=limit, window=window)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return app
+
+
+def test_requests_within_limit_pass() -> None:
+    client = TestClient(_make_app(limit=5))
+    for _ in range(5):
+        assert client.get("/ping").status_code == 200
+
+
+def test_requests_exceeding_limit_return_429() -> None:
+    client = TestClient(_make_app(limit=2))
+    client.get("/ping")
+    client.get("/ping")
+    response = client.get("/ping")
+    assert response.status_code == 429
+    body = response.json()
+    assert body["type"].endswith("too-many-requests")
+    assert "Retry-After" in response.headers
+
+
+def test_forwarded_for_header_used_as_key() -> None:
+    client = TestClient(_make_app(limit=1))
+    client.get("/ping", headers={"X-Forwarded-For": "10.0.0.1"})
+    response = client.get("/ping", headers={"X-Forwarded-For": "10.0.0.1"})
+    assert response.status_code == 429
+
+    response2 = client.get("/ping", headers={"X-Forwarded-For": "10.0.0.2"})
+    assert response2.status_code == 200


### PR DESCRIPTION
## Summary
- `ThrottleMiddleware` を新規実装 (`src/nene2/middleware/throttle.py`)
- 固定ウィンドウ方式、in-memory dict + threading.Lock
- 超過時に 429 + Retry-After ヘッダー付き Problem Details
- `AppSettings.throttle_enabled/limit/window` で設定
- `src/example/app.py` に組み込み
- ADR-0006: レート制限設計

Closes #24

## Test plan
- [x] 86 tests pass (coverage 93%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)