### PR TITLE
feat: CORS 設定を AppSettings から読み込む (#25)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -1,6 +1,7 @@
 """Application factory — wires dependencies and registers routes."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
@@ -76,6 +77,14 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    if cfg.cors_enabled:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cfg.cors_origins,
+            allow_credentials=cfg.cors_allow_credentials,
+            allow_methods=cfg.cors_allow_methods,
+            allow_headers=cfg.cors_allow_headers,
+        )
     if cfg.throttle_enabled:
         app.add_middleware(
             ThrottleMiddleware,

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -18,6 +18,12 @@ class AppSettings(BaseSettings):
     throttle_limit: int = 60
     throttle_window: int = 60  # seconds
 
+    cors_enabled: bool = False
+    cors_origins: list[str] = []
+    cors_allow_credentials: bool = False
+    cors_allow_methods: list[str] = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    cors_allow_headers: list[str] = ["*"]
+
     db_adapter: str = "sqlite"
     db_name: str = ":memory:"
     db_host: str = "localhost"

--- a/tests/example/test_cors.py
+++ b/tests/example/test_cors.py
@@ -1,0 +1,42 @@
+"""Tests for CORS configuration via AppSettings."""
+
+from fastapi.testclient import TestClient
+
+from example.app import create_app
+from nene2.config import AppSettings
+
+
+def test_cors_disabled_by_default() -> None:
+    cfg = AppSettings(throttle_enabled=False)
+    client = TestClient(create_app(cfg))
+    response = client.get("/health", headers={"Origin": "http://example.com"})
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_cors_enabled_returns_allow_origin() -> None:
+    cfg = AppSettings(
+        cors_enabled=True,
+        cors_origins=["http://localhost:3000"],
+        throttle_enabled=False,
+    )
+    client = TestClient(create_app(cfg))
+    response = client.get("/health", headers={"Origin": "http://localhost:3000"})
+    assert response.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+
+
+def test_cors_preflight_returns_204() -> None:
+    cfg = AppSettings(
+        cors_enabled=True,
+        cors_origins=["http://localhost:3000"],
+        throttle_enabled=False,
+    )
+    client = TestClient(create_app(cfg))
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code in (200, 204)
+    assert "Access-Control-Allow-Origin" in response.headers


### PR DESCRIPTION
## Summary
- `AppSettings` に `cors_enabled/origins/allow_credentials/allow_methods/allow_headers` を追加
- `cors_enabled=True` 時に FastAPI 組み込み `CORSMiddleware` を自動追加
- `src/example/app.py` に組み込み

Closes #25

## Test plan
- [x] 89 tests pass (coverage 94%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)