### PR TITLE
feat: TokenVerifierProtocol と BearerTokenMiddleware を実装する (#32)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
+from nene2.auth import BearerTokenMiddleware, LocalTokenVerifier
 from nene2.config import AppSettings
 from nene2.database import (
     DatabaseHealthCheck,
@@ -77,6 +78,11 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    if cfg.bearer_token_enabled:
+        app.add_middleware(
+            BearerTokenMiddleware,
+            verifier=LocalTokenVerifier(cfg.bearer_tokens),
+        )
     if cfg.cors_enabled:
         app.add_middleware(
             CORSMiddleware,

--- a/src/nene2/auth/__init__.py
+++ b/src/nene2/auth/__init__.py
@@ -1,0 +1,7 @@
+"""NENE2 authentication layer."""
+
+from .bearer_token import BearerTokenMiddleware
+from .interfaces import TokenVerifierProtocol
+from .local_verifier import LocalTokenVerifier
+
+__all__ = ["BearerTokenMiddleware", "LocalTokenVerifier", "TokenVerifierProtocol"]

--- a/src/nene2/auth/bearer_token.py
+++ b/src/nene2/auth/bearer_token.py
@@ -1,0 +1,46 @@
+"""Bearer token authentication middleware.
+
+Validates Authorization: Bearer <token> header.
+Returns 401 Problem Details when token is absent or invalid.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
+
+from .interfaces import TokenVerifierProtocol
+
+_WWW_AUTH = 'Bearer realm="api"'
+
+
+class BearerTokenMiddleware(BaseHTTPMiddleware):
+    """Require a valid Bearer token on every request."""
+
+    def __init__(self, app: object, *, verifier: TokenVerifierProtocol) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._verifier = verifier
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            response = problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                "A valid Bearer token is required.",
+            )
+            response.headers["WWW-Authenticate"] = _WWW_AUTH
+            return response
+        token = auth[len("Bearer "):]
+        if not self._verifier.verify(token):
+            response = problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                "The provided token is invalid or expired.",
+            )
+            response.headers["WWW-Authenticate"] = _WWW_AUTH
+            return response
+        return await call_next(request)

--- a/src/nene2/auth/interfaces.py
+++ b/src/nene2/auth/interfaces.py
@@ -1,0 +1,10 @@
+"""Authentication interfaces."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TokenVerifierProtocol(Protocol):
+    """Verify an authentication token."""
+
+    def verify(self, token: str) -> bool: ...

--- a/src/nene2/auth/local_verifier.py
+++ b/src/nene2/auth/local_verifier.py
@@ -1,0 +1,17 @@
+"""Local token verifier — compares against a fixed set of allowed tokens.
+
+For development and testing only. In production, implement TokenVerifierProtocol
+against your actual auth backend (database, external IdP, JWT, etc.).
+"""
+
+import secrets
+
+
+class LocalTokenVerifier:
+    """Verify tokens against a fixed allowlist using constant-time comparison."""
+
+    def __init__(self, allowed_tokens: list[str]) -> None:
+        self._allowed = allowed_tokens
+
+    def verify(self, token: str) -> bool:
+        return any(secrets.compare_digest(token, allowed) for allowed in self._allowed)

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -24,6 +24,9 @@ class AppSettings(BaseSettings):
     cors_allow_methods: list[str] = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     cors_allow_headers: list[str] = ["*"]
 
+    bearer_token_enabled: bool = False
+    bearer_tokens: list[str] = []
+
     db_adapter: str = "sqlite"
     db_name: str = ":memory:"
     db_host: str = "localhost"

--- a/tests/nene2/auth/test_bearer_token.py
+++ b/tests/nene2/auth/test_bearer_token.py
@@ -1,0 +1,60 @@
+"""Tests for BearerTokenMiddleware and LocalTokenVerifier."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.auth import BearerTokenMiddleware, LocalTokenVerifier
+
+
+def _make_app(tokens: list[str]) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BearerTokenMiddleware, verifier=LocalTokenVerifier(tokens))
+
+    @app.get("/secret")
+    async def secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return app
+
+
+def test_valid_token_returns_200() -> None:
+    client = TestClient(_make_app(["valid-token-abc"]))
+    response = client.get("/secret", headers={"Authorization": "Bearer valid-token-abc"})
+    assert response.status_code == 200
+
+
+def test_missing_auth_header_returns_401() -> None:
+    client = TestClient(_make_app(["valid-token-abc"]))
+    response = client.get("/secret")
+    assert response.status_code == 401
+    assert "WWW-Authenticate" in response.headers
+    body = response.json()
+    assert body["type"].endswith("unauthorized")
+
+
+def test_invalid_token_returns_401() -> None:
+    client = TestClient(_make_app(["valid-token-abc"]))
+    response = client.get("/secret", headers={"Authorization": "Bearer wrong-token"})
+    assert response.status_code == 401
+
+
+def test_non_bearer_scheme_returns_401() -> None:
+    client = TestClient(_make_app(["valid-token-abc"]))
+    response = client.get("/secret", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("token", ["tok-a", "tok-b", "tok-c"])
+def test_multiple_allowed_tokens(token: str) -> None:
+    client = TestClient(_make_app(["tok-a", "tok-b", "tok-c"]))
+    response = client.get("/secret", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+
+
+def test_local_verifier_constant_time() -> None:
+    verifier = LocalTokenVerifier(["secret-token"])
+    assert verifier.verify("secret-token") is True
+    assert verifier.verify("wrong") is False
+    assert verifier.verify("") is False


### PR DESCRIPTION
## Summary
- `src/nene2/auth/` パッケージを新規作成
- `TokenVerifierProtocol` — `verify(token) -> bool` インターフェース
- `LocalTokenVerifier` — `secrets.compare_digest` による定数時間比較（timing attack対策）
- `BearerTokenMiddleware` — Authorization: Bearer 検証、401 Problem Details + WWW-Authenticate
- `AppSettings.bearer_token_enabled/bearer_tokens` で設定
- 8テスト (parametrize含む)

Closes #32

## Test plan
- [x] 97 tests pass (coverage 94%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)