### PR TITLE
feat: ApiKeyAuthMiddleware を実装する (#33)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
-from nene2.auth import BearerTokenMiddleware, LocalTokenVerifier
+from nene2.auth import ApiKeyAuthMiddleware, BearerTokenMiddleware, LocalTokenVerifier
 from nene2.config import AppSettings
 from nene2.database import (
     DatabaseHealthCheck,
@@ -78,6 +78,11 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    if cfg.api_key_enabled:
+        app.add_middleware(
+            ApiKeyAuthMiddleware,
+            verifier=LocalTokenVerifier(cfg.api_keys),
+        )
     if cfg.bearer_token_enabled:
         app.add_middleware(
             BearerTokenMiddleware,

--- a/src/nene2/auth/__init__.py
+++ b/src/nene2/auth/__init__.py
@@ -1,7 +1,13 @@
 """NENE2 authentication layer."""
 
+from .api_key import ApiKeyAuthMiddleware
 from .bearer_token import BearerTokenMiddleware
 from .interfaces import TokenVerifierProtocol
 from .local_verifier import LocalTokenVerifier
 
-__all__ = ["BearerTokenMiddleware", "LocalTokenVerifier", "TokenVerifierProtocol"]
+__all__ = [
+    "ApiKeyAuthMiddleware",
+    "BearerTokenMiddleware",
+    "LocalTokenVerifier",
+    "TokenVerifierProtocol",
+]

--- a/src/nene2/auth/api_key.py
+++ b/src/nene2/auth/api_key.py
@@ -1,0 +1,34 @@
+"""API Key authentication middleware.
+
+Validates X-Api-Key header using a TokenVerifierProtocol.
+Returns 401 Problem Details when key is absent or invalid.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
+
+from .interfaces import TokenVerifierProtocol
+
+_API_KEY_HEADER = "X-Api-Key"
+
+
+class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
+    """Require a valid X-Api-Key header on every request."""
+
+    def __init__(self, app: object, *, verifier: TokenVerifierProtocol) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._verifier = verifier
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        api_key = request.headers.get(_API_KEY_HEADER, "")
+        if not api_key or not self._verifier.verify(api_key):
+            return problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                "A valid X-Api-Key header is required.",
+            )
+        return await call_next(request)

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -27,6 +27,9 @@ class AppSettings(BaseSettings):
     bearer_token_enabled: bool = False
     bearer_tokens: list[str] = []
 
+    api_key_enabled: bool = False
+    api_keys: list[str] = []
+
     db_adapter: str = "sqlite"
     db_name: str = ":memory:"
     db_host: str = "localhost"

--- a/tests/nene2/auth/test_api_key.py
+++ b/tests/nene2/auth/test_api_key.py
@@ -1,0 +1,45 @@
+"""Tests for ApiKeyAuthMiddleware."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.auth import ApiKeyAuthMiddleware, LocalTokenVerifier
+
+
+def _make_app(keys: list[str]) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(ApiKeyAuthMiddleware, verifier=LocalTokenVerifier(keys))
+
+    @app.get("/secret")
+    async def secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return app
+
+
+def test_valid_api_key_returns_200() -> None:
+    client = TestClient(_make_app(["my-api-key"]))
+    response = client.get("/secret", headers={"X-Api-Key": "my-api-key"})
+    assert response.status_code == 200
+
+
+def test_missing_api_key_returns_401() -> None:
+    client = TestClient(_make_app(["my-api-key"]))
+    response = client.get("/secret")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["type"].endswith("unauthorized")
+
+
+def test_invalid_api_key_returns_401() -> None:
+    client = TestClient(_make_app(["my-api-key"]))
+    response = client.get("/secret", headers={"X-Api-Key": "wrong-key"})
+    assert response.status_code == 401
+
+
+def test_multiple_allowed_keys() -> None:
+    client = TestClient(_make_app(["key-a", "key-b"]))
+    assert client.get("/secret", headers={"X-Api-Key": "key-a"}).status_code == 200
+    assert client.get("/secret", headers={"X-Api-Key": "key-b"}).status_code == 200
+    assert client.get("/secret", headers={"X-Api-Key": "key-c"}).status_code == 401


### PR DESCRIPTION
## Summary
- `ApiKeyAuthMiddleware` を新規実装 (`src/nene2/auth/api_key.py`)
- `X-Api-Key` ヘッダーを `LocalTokenVerifier` で検証、無効時に 401 Problem Details
- `AppSettings.api_key_enabled/api_keys` で設定
- `src/example/app.py` に組み込み

Closes #33

## Test plan
- [x] 101 tests pass (coverage 94%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)