### PR TITLE
refactor: SqliteRepository を SqlAlchemyRepository にリネームして MySQL/PostgreSQL に対応する (#40)

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -28,7 +28,7 @@ from nene2.validation.exceptions import ValidationException
 from .note.exceptions import NoteNotFoundExceptionHandler
 from .note.handler import make_note_router
 from .note.repository import InMemoryNoteRepository, NoteRepositoryInterface
-from .note.sqlite_repository import SqliteNoteRepository
+from .note.sqlalchemy_repository import SqlAlchemyNoteRepository
 from .note.use_case import (
     CreateNoteUseCase,
     DeleteNoteUseCase,
@@ -40,7 +40,7 @@ from .schema import ensure_schema
 from .tag.exceptions import TagNotFoundExceptionHandler
 from .tag.handler import make_tag_router
 from .tag.repository import InMemoryTagRepository, TagRepositoryInterface
-from .tag.sqlite_repository import SqliteTagRepository
+from .tag.sqlalchemy_repository import SqlAlchemyTagRepository
 from .tag.use_case import (
     CreateTagUseCase,
     DeleteTagUseCase,
@@ -63,7 +63,11 @@ def _build_repositories(
         )
         ensure_schema(engine)
         executor = SqlAlchemyQueryExecutor(engine)
-        return SqliteNoteRepository(executor), SqliteTagRepository(executor), executor
+        return SqlAlchemyNoteRepository(executor), SqlAlchemyTagRepository(executor), executor
+    if cfg.db_adapter in ("mysql", "pgsql"):
+        engine = create_engine(cfg.db_url)
+        executor = SqlAlchemyQueryExecutor(engine)
+        return SqlAlchemyNoteRepository(executor), SqlAlchemyTagRepository(executor), executor
     return InMemoryNoteRepository(), InMemoryTagRepository(), None
 
 

--- a/src/example/note/sqlalchemy_repository.py
+++ b/src/example/note/sqlalchemy_repository.py
@@ -1,4 +1,8 @@
-"""SQLite-backed Note repository using SQLAlchemy Core."""
+"""SQL-backed Note repository using SQLAlchemy Core.
+
+Compatible with SQLite, MySQL, and PostgreSQL — uses standard SQL
+with named parameters (:param) via SQLAlchemy's text() API.
+"""
 
 from nene2.database import DatabaseQueryExecutorInterface
 
@@ -6,8 +10,8 @@ from .entity import Note
 from .repository import NoteRepositoryInterface
 
 
-class SqliteNoteRepository(NoteRepositoryInterface):
-    """Persistent Note repository backed by a SQL database via SQLAlchemy Core."""
+class SqlAlchemyNoteRepository(NoteRepositoryInterface):
+    """Persistent Note repository backed by any SQLAlchemy-supported database."""
 
     def __init__(self, executor: DatabaseQueryExecutorInterface) -> None:
         self._executor = executor

--- a/src/example/tag/sqlalchemy_repository.py
+++ b/src/example/tag/sqlalchemy_repository.py
@@ -1,4 +1,8 @@
-"""SQLite-backed Tag repository using SQLAlchemy Core."""
+"""SQL-backed Tag repository using SQLAlchemy Core.
+
+Compatible with SQLite, MySQL, and PostgreSQL — uses standard SQL
+with named parameters (:param) via SQLAlchemy's text() API.
+"""
 
 from nene2.database import DatabaseQueryExecutorInterface
 
@@ -6,8 +10,8 @@ from .entity import Tag
 from .repository import TagRepositoryInterface
 
 
-class SqliteTagRepository(TagRepositoryInterface):
-    """Persistent Tag repository backed by a SQL database via SQLAlchemy Core."""
+class SqlAlchemyTagRepository(TagRepositoryInterface):
+    """Persistent Tag repository backed by any SQLAlchemy-supported database."""
 
     def __init__(self, executor: DatabaseQueryExecutorInterface) -> None:
         self._executor = executor

--- a/tests/example/note/test_note_repository.py
+++ b/tests/example/note/test_note_repository.py
@@ -1,4 +1,4 @@
-"""Repository contract tests — run against both InMemory and SQLite implementations."""
+"""Repository contract tests — run against both InMemory and SqlAlchemy implementations."""
 
 import pytest
 from sqlalchemy import create_engine
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from nene2.database import SqlAlchemyQueryExecutor
 from src.example.note.entity import Note
 from src.example.note.repository import InMemoryNoteRepository, NoteRepositoryInterface
-from src.example.note.sqlite_repository import SqliteNoteRepository
+from src.example.note.sqlalchemy_repository import SqlAlchemyNoteRepository
 
 
 def _create_schema(executor: SqlAlchemyQueryExecutor) -> None:
@@ -21,18 +21,18 @@ def _create_schema(executor: SqlAlchemyQueryExecutor) -> None:
     )
 
 
-def _sqlite_repo() -> SqliteNoteRepository:
+def _sqlalchemy_repo() -> SqlAlchemyNoteRepository:
     engine = create_engine("sqlite:///:memory:")
     executor = SqlAlchemyQueryExecutor(engine)
     _create_schema(executor)
-    return SqliteNoteRepository(executor)
+    return SqlAlchemyNoteRepository(executor)
 
 
-@pytest.fixture(params=["inmemory", "sqlite"])
+@pytest.fixture(params=["inmemory", "sqlalchemy"])
 def repo(request: pytest.FixtureRequest) -> NoteRepositoryInterface:
     if request.param == "inmemory":
         return InMemoryNoteRepository()
-    return _sqlite_repo()
+    return _sqlalchemy_repo()
 
 
 def test_save_and_find_by_id(repo: NoteRepositoryInterface) -> None:

--- a/tests/example/tag/test_tag_repository.py
+++ b/tests/example/tag/test_tag_repository.py
@@ -1,4 +1,4 @@
-"""Repository contract tests — run against both InMemory and SQLite implementations."""
+"""Repository contract tests — run against both InMemory and SqlAlchemy implementations."""
 
 import pytest
 from sqlalchemy import create_engine
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from nene2.database import SqlAlchemyQueryExecutor
 from src.example.tag.entity import Tag
 from src.example.tag.repository import InMemoryTagRepository, TagRepositoryInterface
-from src.example.tag.sqlite_repository import SqliteTagRepository
+from src.example.tag.sqlalchemy_repository import SqlAlchemyTagRepository
 
 
 def _create_schema(executor: SqlAlchemyQueryExecutor) -> None:
@@ -19,18 +19,18 @@ def _create_schema(executor: SqlAlchemyQueryExecutor) -> None:
     )
 
 
-def _sqlite_repo() -> SqliteTagRepository:
+def _sqlalchemy_repo() -> SqlAlchemyTagRepository:
     engine = create_engine("sqlite:///:memory:")
     executor = SqlAlchemyQueryExecutor(engine)
     _create_schema(executor)
-    return SqliteTagRepository(executor)
+    return SqlAlchemyTagRepository(executor)
 
 
-@pytest.fixture(params=["inmemory", "sqlite"])
+@pytest.fixture(params=["inmemory", "sqlalchemy"])
 def repo(request: pytest.FixtureRequest) -> TagRepositoryInterface:
     if request.param == "inmemory":
         return InMemoryTagRepository()
-    return _sqlite_repo()
+    return _sqlalchemy_repo()
 
 
 def test_save_and_find_by_id(repo: TagRepositoryInterface) -> None:


### PR DESCRIPTION
## Summary
- `SqliteNoteRepository` → `SqlAlchemyNoteRepository` にリネーム
- `SqliteTagRepository` → `SqlAlchemyTagRepository` にリネーム
- `_build_repositories()` が `mysql` / `pgsql` アダプターでも `SqlAlchemyQueryExecutor` を使うよう拡張
- テスト: fixture param を `"sqlite"` → `"sqlalchemy"` に更新

Closes #40

## Test plan
- [x] 104 tests pass (coverage 90%)
- [x] mypy strict — no issues
- [x] ruff check — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)