### PR TITLE
docs: ギャップ対応完了をロードマップに反映する

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -159,6 +159,13 @@ PHP 版追跡・Python 固有の強化:
 | `Example/Tag` (full CRUD) | `example.tag` (全 CRUD) | ✅ |
 | `Example/Comment` (full CRUD) | `example.comment` (全 CRUD) | ✅ |
 | `Example/Health` | `example.health` | ✅ |
+| `Auth/TokenIssuerInterface` | `nene2.auth.TokenIssuerProtocol` | ✅ |
+| `Auth/TokenVerificationException` | `nene2.auth.TokenVerificationException` | ✅ |
+| `Database/DatabaseTransactionManagerInterface` | `nene2.database.DatabaseTransactionManagerInterface` | ✅ |
+| `Database/PdoDatabaseTransactionManager` | `nene2.database.SqlAlchemyTransactionManager` | ✅ |
+| `Mcp/LocalMcpHttpClientInterface` | `nene2.mcp.McpHttpClientProtocol` | ✅ |
+| `Mcp/LocalMcpHttpResponse` | `nene2.mcp.McpHttpResponse` | ✅ |
+| `Mcp/NativeLocalMcpHttpClient` | `nene2.mcp.HttpxMcpClient` | ✅ |
 | `UseCaseInterface` | `nene2.use_case.UseCaseProtocol[I, O]` | ✅ |
 | — | `nene2.use_case.AsyncUseCaseProtocol[I, O]` | ✅ Python 固有 |
 

--- a/uv.lock
+++ b/uv.lock
@@ -930,6 +930,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -966,6 +967,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },


### PR DESCRIPTION
PHP NENE2 との同等性ギャップ (#49, #50, #51) の完了を機能対応表に追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)