### PR TITLE
fix: 未使用インポートを除去して ruff CI を通す

### DIFF
--- a/tests/nene2/database/test_transaction.py
+++ b/tests/nene2/database/test_transaction.py
@@ -5,7 +5,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
 from nene2.database import DatabaseQueryExecutorInterface, SqlAlchemyTransactionManager
-from nene2.database.exceptions import DatabaseConnectionException
 
 
 def _manager() -> SqlAlchemyTransactionManager:

--- a/tests/nene2/mcp/test_http_client.py
+++ b/tests/nene2/mcp/test_http_client.py
@@ -3,7 +3,6 @@
 import json
 
 import httpx
-import pytest
 
 from nene2.mcp import HttpxMcpClient, McpHttpClientProtocol, McpHttpResponse
 


### PR DESCRIPTION
## Summary

- `tests/nene2/database/test_transaction.py` — `DatabaseConnectionException` (F401)
- `tests/nene2/mcp/test_http_client.py` — `pytest` (F401)

前回の PR #58 マージ後に CI が ruff F401 で落ちていたため修正。

## Test plan

- [x] `uv run ruff check src/ tests/` — All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)