### PR TITLE
fix: ruff format を適用して CI フォーマットチェックを通す

### DIFF
--- a/src/example/comment/handler.py
+++ b/src/example/comment/handler.py
@@ -84,9 +84,7 @@ def make_comment_router(
             errors.append(ValidationError("body", "Body must not be empty.", "required"))
         if errors:
             raise ValidationException(errors)
-        comment = update_use_case.execute(
-            UpdateCommentInput(comment_id=comment_id, body=body.body)
-        )
+        comment = update_use_case.execute(UpdateCommentInput(comment_id=comment_id, body=body.body))
         return JSONResponse(_comment_dict(comment))
 
     @router.delete("/{comment_id}", status_code=204)

--- a/src/example/comment/sqlalchemy_repository.py
+++ b/src/example/comment/sqlalchemy_repository.py
@@ -47,9 +47,7 @@ class SqlAlchemyCommentRepository(CommentRepositoryInterface):
         return Comment(id=comment_id, note_id=row["note_id"], body=body)
 
     def delete(self, comment_id: int) -> bool:
-        affected = self._executor.write(
-            "DELETE FROM comments WHERE id = :id", {"id": comment_id}
-        )
+        affected = self._executor.write("DELETE FROM comments WHERE id = :id", {"id": comment_id})
         return affected > 0
 
     def count_by_note(self, note_id: int) -> int:

--- a/src/example/note/handler.py
+++ b/src/example/note/handler.py
@@ -38,6 +38,7 @@ def make_note_router(
     delete_use_case: DeleteNoteUseCase,
 ) -> APIRouter:
     router = APIRouter(prefix="/notes", tags=["notes"])
+
     @router.get("")
     async def list_notes(request: Request) -> JSONResponse:
         pagination = PaginationQueryParser.parse(request)

--- a/src/example/schema.py
+++ b/src/example/schema.py
@@ -10,27 +10,33 @@ from sqlalchemy import Engine, text
 def ensure_schema(engine: Engine) -> None:
     """Create tables if they do not already exist (idempotent)."""
     with engine.begin() as conn:
-        conn.execute(text(
-            "CREATE TABLE IF NOT EXISTS notes ("
-            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "title TEXT NOT NULL,"
-            "body TEXT NOT NULL,"
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
-            "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP"
-            ")"
-        ))
-        conn.execute(text(
-            "CREATE TABLE IF NOT EXISTS tags ("
-            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "name TEXT NOT NULL UNIQUE,"
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
-            ")"
-        ))
-        conn.execute(text(
-            "CREATE TABLE IF NOT EXISTS comments ("
-            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "note_id INTEGER NOT NULL,"
-            "body TEXT NOT NULL,"
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
-            ")"
-        ))
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS notes ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "title TEXT NOT NULL,"
+                "body TEXT NOT NULL,"
+                "created_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
+                "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS tags ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "name TEXT NOT NULL UNIQUE,"
+                "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS comments ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "note_id INTEGER NOT NULL,"
+                "body TEXT NOT NULL,"
+                "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )

--- a/src/example/tag/handler.py
+++ b/src/example/tag/handler.py
@@ -36,6 +36,7 @@ def make_tag_router(
     delete_use_case: DeleteTagUseCase,
 ) -> APIRouter:
     router = APIRouter(prefix="/tags", tags=["tags"])
+
     @router.get("")
     async def list_tags(request: Request) -> JSONResponse:
         pagination = PaginationQueryParser.parse(request)

--- a/src/nene2/auth/bearer_token.py
+++ b/src/nene2/auth/bearer_token.py
@@ -34,7 +34,7 @@ class BearerTokenMiddleware(BaseHTTPMiddleware):
             )
             response.headers["WWW-Authenticate"] = _WWW_AUTH
             return response
-        token = auth[len("Bearer "):]
+        token = auth[len("Bearer ") :]
         try:
             verified = self._verifier.verify(token)
         except TokenVerificationException:

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -54,4 +54,6 @@ class AppSettings(BaseSettings):
         port = self.db_port
         if self.db_adapter == "mysql":
             return f"mysql+pymysql://{self.db_user}:{password}@{self.db_host}:{port}/{self.db_name}"
-        return f"postgresql+psycopg2://{self.db_user}:{password}@{self.db_host}:{port}/{self.db_name}"
+        return (
+            f"postgresql+psycopg2://{self.db_user}:{password}@{self.db_host}:{port}/{self.db_name}"
+        )

--- a/src/nene2/database/interfaces.py
+++ b/src/nene2/database/interfaces.py
@@ -13,9 +13,7 @@ class DatabaseQueryExecutorInterface(ABC):
     """Execute parameterised SQL queries against a database."""
 
     @abstractmethod
-    def fetch_all(
-        self, sql: str, params: dict[str, Any] | None = None
-    ) -> list[dict[str, Any]]: ...
+    def fetch_all(self, sql: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]: ...
 
     @abstractmethod
     def fetch_one(
@@ -39,9 +37,7 @@ class DatabaseTransactionManagerInterface(ABC):
     """
 
     @abstractmethod
-    def transactional[T](
-        self, callback: Callable[[DatabaseQueryExecutorInterface], T]
-    ) -> T:
+    def transactional[T](self, callback: Callable[[DatabaseQueryExecutorInterface], T]) -> T:
         """Run callback inside a transaction; commit on success, rollback on exception."""
         ...
 

--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -19,9 +19,7 @@ class SqlAlchemyQueryExecutor(DatabaseQueryExecutorInterface):
     def __init__(self, engine: Engine) -> None:
         self._engine = engine
 
-    def fetch_all(
-        self, sql: str, params: dict[str, Any] | None = None
-    ) -> list[dict[str, Any]]:
+    def fetch_all(self, sql: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         try:
             with self._engine.connect() as conn:
                 result = conn.execute(text(sql), params or {})
@@ -29,9 +27,7 @@ class SqlAlchemyQueryExecutor(DatabaseQueryExecutorInterface):
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
 
-    def fetch_one(
-        self, sql: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any] | None:
+    def fetch_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
         try:
             with self._engine.connect() as conn:
                 result = conn.execute(text(sql), params or {})
@@ -55,15 +51,11 @@ class _BoundQueryExecutor(DatabaseQueryExecutorInterface):
     def __init__(self, conn: Connection) -> None:
         self._conn = conn
 
-    def fetch_all(
-        self, sql: str, params: dict[str, Any] | None = None
-    ) -> list[dict[str, Any]]:
+    def fetch_all(self, sql: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         result = self._conn.execute(text(sql), params or {})
         return [dict(row._mapping) for row in result]
 
-    def fetch_one(
-        self, sql: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any] | None:
+    def fetch_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
         result = self._conn.execute(text(sql), params or {})
         row = result.fetchone()
         return dict(row._mapping) if row else None
@@ -85,9 +77,7 @@ class SqlAlchemyTransactionManager(DatabaseTransactionManagerInterface):
         self._conn: Connection | None = None
         self._tx: Any = None
 
-    def transactional[T](
-        self, callback: Callable[[DatabaseQueryExecutorInterface], T]
-    ) -> T:
+    def transactional[T](self, callback: Callable[[DatabaseQueryExecutorInterface], T]) -> T:
         try:
             with self._engine.begin() as conn:
                 return callback(_BoundQueryExecutor(conn))

--- a/src/nene2/mcp/http_client.py
+++ b/src/nene2/mcp/http_client.py
@@ -32,13 +32,9 @@ class McpHttpClientProtocol(Protocol):
 
     def get(self, base_url: str, path: str) -> McpHttpResponse: ...
 
-    def post(
-        self, base_url: str, path: str, body: dict[str, object]
-    ) -> McpHttpResponse: ...
+    def post(self, base_url: str, path: str, body: dict[str, object]) -> McpHttpResponse: ...
 
-    def put(
-        self, base_url: str, path: str, body: dict[str, object]
-    ) -> McpHttpResponse: ...
+    def put(self, base_url: str, path: str, body: dict[str, object]) -> McpHttpResponse: ...
 
     def delete(self, base_url: str, path: str) -> McpHttpResponse: ...
 
@@ -64,14 +60,10 @@ class HttpxMcpClient:
     def get(self, base_url: str, path: str) -> McpHttpResponse:
         return self._request("GET", base_url, path, None)
 
-    def post(
-        self, base_url: str, path: str, body: dict[str, object]
-    ) -> McpHttpResponse:
+    def post(self, base_url: str, path: str, body: dict[str, object]) -> McpHttpResponse:
         return self._request("POST", base_url, path, body)
 
-    def put(
-        self, base_url: str, path: str, body: dict[str, object]
-    ) -> McpHttpResponse:
+    def put(self, base_url: str, path: str, body: dict[str, object]) -> McpHttpResponse:
         return self._request("PUT", base_url, path, body)
 
     def delete(self, base_url: str, path: str) -> McpHttpResponse:

--- a/tests/nene2/database/test_transaction.py
+++ b/tests/nene2/database/test_transaction.py
@@ -51,9 +51,7 @@ def test_transactional_rollback_on_exception() -> None:
 def test_transactional_returns_callback_value() -> None:
     mgr = _manager()
     mgr.transactional(lambda ex: ex.write("INSERT INTO items (name) VALUES ('x')"))
-    count = mgr.transactional(
-        lambda ex: ex.fetch_one("SELECT COUNT(*) AS cnt FROM items")
-    )
+    count = mgr.transactional(lambda ex: ex.fetch_one("SELECT COUNT(*) AS cnt FROM items"))
     assert count is not None
     assert count["cnt"] == 1
 


### PR DESCRIPTION
## Summary

`uv run ruff format src/ tests/` を実行して 11 ファイルのフォーマット差分を修正。

## Test plan

- [x] `uv run ruff format --check src/ tests/` — 101 files already formatted
- [x] `uv run ruff check src/ tests/` — All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)