### PR TITLE
refactor: wheel から src/example を除外し nene2 のみをパッケージ化 (#61)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,4 +138,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/nene2", "src/example"]
+packages = ["src/nene2"]


### PR DESCRIPTION
## Summary

- `pyproject.toml` の wheel ターゲットを `["src/nene2"]` のみに変更
- `uv build` でビルド確認済み — wheel に `example` が含まれないことを確認

## Test plan

- [x] `uv build` — ビルド成功
- [x] wheel の中身が `nene2/` のみ（`example/` なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)