### PR TITLE
docs: DB_ADAPTER別のdb_url生成例を設定リファレンスに追記 (FT2-F5)

### DIFF
--- a/docs/ja/reference/configuration.md
+++ b/docs/ja/reference/configuration.md
@@ -69,13 +69,22 @@
 | `DB_USER` | `""` | DB ユーザー名（SQLite では無視） |
 | `DB_PASSWORD` | `""` | DB パスワード — `SecretStr` 型（ログに出力されない） |
 
-### 接続 URL の例
+### 生成される `db_url`
 
-| アダプター | 生成される URL |
-|---|---|
-| `sqlite` | `sqlite:///path/to/db.sqlite3` |
-| `mysql` | `mysql+pymysql://user:pass@host:3306/dbname` |
-| `pgsql` | `postgresql+psycopg2://user:pass@host:5432/dbname` |
+`AppSettings.db_url` は各変数から自動生成されるプロパティです。
+アダプターと代表的な `DB_NAME` の組み合わせごとに生成される URL を示します。
+
+| `DB_ADAPTER` | `DB_NAME` | 生成される `db_url` |
+|---|---|---|
+| `sqlite` | `:memory:` | `sqlite:///:memory:` |
+| `sqlite` | `./data/app.db` | `sqlite:///./data/app.db` |
+| `sqlite` | `/var/lib/app.db` | `sqlite:////var/lib/app.db` |
+| `mysql` | `mydb` | `mysql+pymysql://user:pass@localhost:3306/mydb` |
+| `pgsql` | `mydb` | `postgresql+psycopg2://user:pass@localhost:5432/mydb` |
+
+> SQLite インメモリ DB（`DB_NAME=:memory:`）を使う場合は `create_engine()` に
+> `poolclass=StaticPool` を渡してください。詳細は
+> [SQLAlchemy リポジトリのハウツー](../how-to/sqlalchemy-repository.md) を参照してください。
 
 ## .env ファイル例
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,13 +69,22 @@ Uses a fixed-window algorithm keyed on client IP. Exceeding the limit returns `4
 | `DB_USER` | `""` | Database user (ignored for SQLite) |
 | `DB_PASSWORD` | `""` | Database password — stored as `SecretStr`, never logged |
 
-### Generated connection URLs
+### Generated `db_url`
 
-| Adapter | URL format |
-|---|---|
-| `sqlite` | `sqlite:///path/to/db.sqlite3` |
-| `mysql` | `mysql+pymysql://user:pass@host:3306/dbname` |
-| `pgsql` | `postgresql+psycopg2://user:pass@host:5432/dbname` |
+`AppSettings.db_url` is a computed property built from the variables above.
+The table below shows what URL is generated for each adapter + common `DB_NAME` values:
+
+| `DB_ADAPTER` | `DB_NAME` | Generated `db_url` |
+|---|---|---|
+| `sqlite` | `:memory:` | `sqlite:///:memory:` |
+| `sqlite` | `./data/app.db` | `sqlite:///./data/app.db` |
+| `sqlite` | `/var/lib/app.db` | `sqlite:////var/lib/app.db` |
+| `mysql` | `mydb` | `mysql+pymysql://user:pass@localhost:3306/mydb` |
+| `pgsql` | `mydb` | `postgresql+psycopg2://user:pass@localhost:5432/mydb` |
+
+> For SQLite in-memory databases (`DB_NAME=:memory:`), pass `poolclass=StaticPool` to
+> `create_engine()` so all connections share the same in-process database.
+> See the [SQLAlchemy repository how-to](../how-to/sqlalchemy-repository.md) for details.
 
 ## Example `.env`
 


### PR DESCRIPTION
## Summary

- `docs/reference/configuration.md` の「Generated `db_url`」セクションを拡充（EN/JA）
- `:memory:` / ファイルパス / MySQL / PostgreSQL の具体的な URL 例を追加
- `StaticPool` が必要なケースへの注記とハウツーガイドへのリンクを追加

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)