### PR TITLE
docs: list[str]型の環境変数はJSON配列形式が必要なことを明記 (FT3-F1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,21 @@ APP_ENV=local
 APP_DEBUG=false
 APP_NAME=nene2-python
 
+# 認証設定
+# list型フィールドは JSON 配列形式で書く（プレーン文字列は JSONDecodeError になる）
+BEARER_TOKEN_ENABLED=false
+BEARER_TOKENS=[]
+# BEARER_TOKENS=["token-1","token-2"]
+
+API_KEY_ENABLED=false
+API_KEYS=[]
+# API_KEYS=["key-1","key-2"]
+
+# CORS設定
+CORS_ENABLED=false
+CORS_ORIGINS=[]
+# CORS_ORIGINS=["https://example.com","https://app.example.com"]
+
 # データベース設定
 # sqlite: インメモリ（テスト用）
 # DB_ADAPTER=sqlite

--- a/docs/ja/reference/configuration.md
+++ b/docs/ja/reference/configuration.md
@@ -42,7 +42,7 @@
 | 変数 | デフォルト | 説明 |
 |---|---|---|
 | `CORS_ENABLED` | `false` | CORS ミドルウェアを有効化 |
-| `CORS_ORIGINS` | `[]` | 許可オリジンのリスト（カンマ区切り） |
+| `CORS_ORIGINS` | `[]` | 許可オリジンのリスト — JSON配列形式: `["https://a.com","https://b.com"]` |
 | `CORS_ALLOW_CREDENTIALS` | `false` | クレデンシャルを許可するか |
 | `CORS_ALLOW_METHODS` | `GET,POST,PUT,DELETE,OPTIONS` | 許可メソッド |
 | `CORS_ALLOW_HEADERS` | `*` | 許可ヘッダー |
@@ -54,9 +54,14 @@
 | 変数 | デフォルト | 説明 |
 |---|---|---|
 | `BEARER_TOKEN_ENABLED` | `false` | Bearer Token 認証を有効化 |
-| `BEARER_TOKENS` | `[]` | 有効なトークンのリスト（カンマ区切り） |
+| `BEARER_TOKENS` | `[]` | 有効なトークンのリスト — JSON配列形式: `["tok-1","tok-2"]` |
 | `API_KEY_ENABLED` | `false` | API Key 認証を有効化 |
-| `API_KEYS` | `[]` | 有効な API キーのリスト（カンマ区切り） |
+| `API_KEYS` | `[]` | 有効な API キーのリスト — JSON配列形式: `["key-1","key-2"]` |
+
+> **リスト型フィールドは `.env` で JSON 配列形式で書く必要があります。**
+> `BEARER_TOKENS=token-1`（プレーン文字列）と書くと起動時に `JSONDecodeError` になります。
+> `BEARER_TOKENS=["token-1","token-2"]` のように書いてください。
+> `API_KEYS` / `CORS_ORIGINS` も同様です。
 
 ## データベース設定
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,9 +54,14 @@ Uses a fixed-window algorithm keyed on client IP. Exceeding the limit returns `4
 | Variable | Default | Description |
 |---|---|---|
 | `BEARER_TOKEN_ENABLED` | `false` | Enable Bearer Token auth |
-| `BEARER_TOKENS` | `[]` | Valid tokens (comma-separated) |
+| `BEARER_TOKENS` | `[]` | Valid tokens — JSON array format: `["tok-1","tok-2"]` |
 | `API_KEY_ENABLED` | `false` | Enable API Key auth |
-| `API_KEYS` | `[]` | Valid API keys (comma-separated) |
+| `API_KEYS` | `[]` | Valid API keys — JSON array format: `["key-1","key-2"]` |
+
+> **List fields require JSON array syntax in `.env`.**
+> Writing `BEARER_TOKENS=token-1` (plain string) causes a `JSONDecodeError` at startup.
+> Always use `BEARER_TOKENS=["token-1","token-2"]`.
+> The same applies to `API_KEYS` and `CORS_ORIGINS`.
 
 ## Database
 
@@ -97,10 +102,10 @@ THROTTLE_LIMIT=100
 THROTTLE_WINDOW=60
 
 CORS_ENABLED=true
-CORS_ORIGINS=https://example.com,https://app.example.com
+CORS_ORIGINS=["https://example.com","https://app.example.com"]
 
 BEARER_TOKEN_ENABLED=true
-BEARER_TOKENS=secret-token-1,secret-token-2
+BEARER_TOKENS=["secret-token-1","secret-token-2"]
 
 DB_ADAPTER=mysql
 DB_HOST=db.example.com


### PR DESCRIPTION
## Summary

- `docs/reference/configuration.md` の `BEARER_TOKENS` / `API_KEYS` / `CORS_ORIGINS` に JSON 配列形式の注記を追加（EN/JA）
- Example `.env` のサンプル値を誤った形式（カンマ区切り）から正しい形式（JSON 配列）に修正
- `.env.example` に認証・CORS セクションを追加し、コメントで書き方を明示

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)