### PR TITLE
docs: MCP howto にMCPとHTTP APIでDB共有する方法を追記 (FT3-F2)

### DIFF
--- a/docs/howto/mcp-setup.md
+++ b/docs/howto/mcp-setup.md
@@ -75,3 +75,34 @@ server = create_mcp_server()
 server.run(transport="sse")          # Server-Sent Events
 server.run(transport="streamable-http")  # HTTP streaming
 ```
+
+---
+
+## Sharing state between MCP server and HTTP API
+
+The MCP server runs as a **separate process** from the HTTP API.
+`InMemoryXxxRepository` creates its own isolated store per process —
+data written via MCP is not visible to the HTTP API, and vice versa.
+
+To share state, point both processes at the same persistent database:
+
+**HTTP API `.env`**:
+
+```dotenv
+DB_ADAPTER=sqlite
+DB_NAME=/absolute/path/to/shared.db
+```
+
+**Claude Desktop `claude_desktop_config.json`**:
+
+```json
+"env": {
+  "DB_ADAPTER": "sqlite",
+  "DB_NAME": "/absolute/path/to/shared.db"
+}
+```
+
+Both processes open the same SQLite file via SQLAlchemy.
+SQLite's WAL mode handles concurrent reads safely for light workloads.
+
+> For high-concurrency production use, prefer MySQL or PostgreSQL.

--- a/docs/ja/howto/mcp-setup.md
+++ b/docs/ja/howto/mcp-setup.md
@@ -75,3 +75,34 @@ server = create_mcp_server()
 server.run(transport="sse")          # Server-Sent Events
 server.run(transport="streamable-http")  # HTTP ストリーミング
 ```
+
+---
+
+## MCP サーバーと HTTP API でデータを共有する
+
+MCP サーバーは HTTP API とは**別プロセス**として起動します。
+`InMemoryXxxRepository` はプロセスごとに独立したストアを持つため、
+MCP で書き込んだデータは HTTP API からは見えません（逆も同様）。
+
+データを共有するには、両者が同じ永続化 DB ファイルを参照するように設定します。
+
+**HTTP API の `.env`**:
+
+```dotenv
+DB_ADAPTER=sqlite
+DB_NAME=/absolute/path/to/shared.db
+```
+
+**Claude Desktop の `claude_desktop_config.json`**:
+
+```json
+"env": {
+  "DB_ADAPTER": "sqlite",
+  "DB_NAME": "/absolute/path/to/shared.db"
+}
+```
+
+両プロセスが SQLAlchemy 経由で同じ SQLite ファイルを開きます。
+SQLite の WAL モードは軽量な同時アクセスを安全に処理します。
+
+> 高並列のプロダクション環境では MySQL や PostgreSQL を推奨します。


### PR DESCRIPTION
## Summary

- `docs/howto/mcp-setup.md` に「MCP サーバーと HTTP API でデータを共有する」セクションを追加（EN/JA）
- InMemory は別プロセスで共有不可であることを明記
- 同じ SQLite ファイルを両者で参照する設定例を追加

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)