### PR TITLE
docs: Claude Desktop MCP設定にWSL2パターンを追加 (FT3-F3)

### DIFF
--- a/docs/howto/mcp-setup.md
+++ b/docs/howto/mcp-setup.md
@@ -12,7 +12,14 @@ Once configured, Claude Desktop and the `claude` CLI can perform CRUD operations
 
 ## Claude Desktop configuration
 
-Add the following to `claude_desktop_config.json`:
+`claude_desktop_config.json` is located at:
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+### macOS / Linux (native)
 
 ```json
 {
@@ -37,6 +44,48 @@ Add the following to `claude_desktop_config.json`:
 ```
 
 Replace `/path/to/nene2-python` with the absolute path to this repository.
+
+### Windows + WSL2
+
+Claude Desktop runs on Windows but the project lives inside WSL2.
+Use `wsl` as the command to bridge them:
+
+```json
+{
+  "mcpServers": {
+    "nene2-example": {
+      "command": "wsl",
+      "args": [
+        "-e", "bash", "-c",
+        "cd /home/<user>/nene2-python && PYTHONPATH=src uv run python -m example.mcp"
+      ],
+      "env": {
+        "DB_ADAPTER": "sqlite",
+        "DB_NAME": "/home/<user>/nene2-python/data/nene2.db"
+      }
+    }
+  }
+}
+```
+
+> All paths must be **WSL Linux paths** (e.g. `/home/user/...`), not Windows paths.
+> The `DB_NAME` must also be a Linux path so SQLite creates the file inside WSL.
+
+For a project installed via `uv add git+...` (not the nene2-python repo itself):
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "command": "wsl",
+      "args": [
+        "-e", "bash", "-c",
+        "cd /home/<user>/my-project && PYTHONPATH=src uv run python -m mcp_server"
+      ]
+    }
+  }
+}
+```
 
 ## Available tools
 

--- a/docs/ja/howto/mcp-setup.md
+++ b/docs/ja/howto/mcp-setup.md
@@ -12,7 +12,14 @@ Claude Desktop や `claude` CLI から直接 CRUD 操作が可能になります
 
 ## Claude Desktop への設定
 
-`claude_desktop_config.json` に以下を追加します:
+`claude_desktop_config.json` のパス:
+
+| OS | パス |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+### macOS / Linux（ネイティブ）
 
 ```json
 {
@@ -37,6 +44,48 @@ Claude Desktop や `claude` CLI から直接 CRUD 操作が可能になります
 ```
 
 `/path/to/nene2-python` をリポジトリの絶対パスに変更してください。
+
+### Windows + WSL2
+
+Claude Desktop は Windows で動作しますが、プロジェクトは WSL2 内にあります。
+`wsl` コマンドでブリッジします:
+
+```json
+{
+  "mcpServers": {
+    "nene2-example": {
+      "command": "wsl",
+      "args": [
+        "-e", "bash", "-c",
+        "cd /home/<user>/nene2-python && PYTHONPATH=src uv run python -m example.mcp"
+      ],
+      "env": {
+        "DB_ADAPTER": "sqlite",
+        "DB_NAME": "/home/<user>/nene2-python/data/nene2.db"
+      }
+    }
+  }
+}
+```
+
+> パスはすべて **WSL の Linux パス**（例: `/home/user/...`）で指定します。
+> `DB_NAME` も Linux パスにすることで、SQLite ファイルが WSL 内に作成されます。
+
+`uv add git+...` でインストールした外部プロジェクトの場合:
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "command": "wsl",
+      "args": [
+        "-e", "bash", "-c",
+        "cd /home/<user>/my-project && PYTHONPATH=src uv run python -m mcp_server"
+      ]
+    }
+  }
+}
+```
 
 ## 利用可能なツール
 


### PR DESCRIPTION
## Summary

- `docs/howto/mcp-setup.md` を拡充（EN/JA）
  - `claude_desktop_config.json` の OS 別パスを追記
  - macOS/Linux（ネイティブ）と Windows+WSL2 の設定例を分離
  - WSL2 パターン：`wsl -e bash -c` でブリッジする方法を追加
  - `uv add git+...` 外部プロジェクト向け WSL2 設定例も追加

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)