### PR TITLE
chore: PyPI 公開メタデータ追加 & export-openapi スクリプト参照修正

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hideyukiMORI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/ja/reference/api.md
+++ b/docs/ja/reference/api.md
@@ -2,7 +2,7 @@
 
 nene2-python example アプリが提供するエンドポイントの一覧です。
 
-> OpenAPI スキーマ（機械可読）は `uv run export-openapi` で `docs/openapi.yaml` に生成できます。
+> OpenAPI スキーマ（機械可読）は `uv run python src/scripts/export_openapi.py` で `docs/openapi.yaml` に生成できます。
 > 開発サーバー起動後は `http://localhost:8080/docs` で Swagger UI を参照できます。
 
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2,7 +2,7 @@
 
 Endpoints provided by the nene2-python example application.
 
-> Machine-readable schema: run `uv run export-openapi` to generate `docs/openapi.yaml`.  
+> Machine-readable schema: run `uv run python src/scripts/export_openapi.py` to generate `docs/openapi.yaml`.  
 > Interactive docs: start the dev server and open `http://localhost:8080/docs`.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,24 @@
 name = "nene2-python"
 version = "0.1.0"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "hideyukiMORI", email = "info.xion.cc@gmail.com"}]
 requires-python = ">=3.12"
+keywords = ["fastapi", "pydantic", "sqlalchemy", "mcp", "api", "framework", "clean-architecture"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Framework :: FastAPI",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Typing :: Typed",
+]
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
@@ -17,8 +34,11 @@ dependencies = [
     "httpx>=0.27",
 ]
 
-[project.scripts]
-export-openapi = "scripts.export_openapi:main"
+[project.urls]
+Homepage = "https://github.com/hideyukiMORI/nene2-python"
+Repository = "https://github.com/hideyukiMORI/nene2-python"
+Documentation = "https://github.com/hideyukiMORI/nene2-python/tree/main/docs"
+"Bug Tracker" = "https://github.com/hideyukiMORI/nene2-python/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

- `LICENSE` ファイルを追加（MIT, 2026 hideyukiMORI）
- `pyproject.toml` に PyPI 必須メタデータを追加: `readme`, `license`, `authors`, `keywords`, `classifiers`, `[project.urls]`
- `[project.scripts]` の `export-openapi` エントリを削除（`example/` がホイール外のため pip インストール後に `ModuleNotFoundError` が発生する問題）
- `docs/reference/api.md` と `docs/ja/reference/api.md` のコマンド参照を `uv run export-openapi` → `uv run python src/scripts/export_openapi.py` に変更

## Test plan

- [x] 167 tests, 91.77% coverage — all passed
- [x] mypy strict — no issues
- [x] ruff check + format — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)