### PR TITLE
docs: ブロークンリンク修正・ADRリンク形式統一

### DIFF
--- a/docs/de/tutorials/getting-started.md
+++ b/docs/de/tutorials/getting-started.md
@@ -51,4 +51,4 @@ Mehr als 167 Tests sollten erfolgreich sein.
 
 ## Nächste Schritte
 
-- [Konfigurationsreferenz](../reference/configuration.md) — Datenbank und Authentifizierung über Umgebungsvariablen konfigurieren
+- [Konfigurationsreferenz](../../reference/configuration.md) — Datenbank und Authentifizierung über Umgebungsvariablen konfigurieren

--- a/docs/explanation/design-philosophy.md
+++ b/docs/explanation/design-philosophy.md
@@ -58,11 +58,11 @@ Because UseCases are independent of HTTP and database, they can be registered di
 
 Individual design decisions are recorded in Architecture Decision Records:
 
-- [ADR-0001: Toolchain](../adr/0001-toolchain)
-- [ADR-0002: Clean Architecture](../adr/0002-clean-architecture)
-- [ADR-0003: Security First](../adr/0003-security-first)
-- [ADR-0004: AI-First Design](../adr/0004-ai-first-design)
-- [ADR-0005: Logging](../adr/0005-logging)
-- [ADR-0006: Rate Limiting](../adr/0006-rate-limiting)
-- [ADR-0009: MCP Design](../adr/0009-mcp-design)
-- [ADR-0010: AsyncUseCase Pattern](../adr/0010-async-use-case)
+- [ADR-0001: Toolchain](../adr/0001-toolchain.md)
+- [ADR-0002: Clean Architecture](../adr/0002-clean-architecture.md)
+- [ADR-0003: Security First](../adr/0003-security-first.md)
+- [ADR-0004: AI-First Design](../adr/0004-ai-first-design.md)
+- [ADR-0005: Logging](../adr/0005-logging.md)
+- [ADR-0006: Rate Limiting](../adr/0006-rate-limiting.md)
+- [ADR-0009: MCP Design](../adr/0009-mcp-design.md)
+- [ADR-0010: AsyncUseCase Pattern](../adr/0010-async-use-case.md)

--- a/docs/fr/tutorials/getting-started.md
+++ b/docs/fr/tutorials/getting-started.md
@@ -51,4 +51,4 @@ Plus de 167 tests doivent tous réussir.
 
 ## Étapes suivantes
 
-- [Référence de configuration](../reference/configuration.md) — Configurer la base de données et l'authentification via les variables d'environnement
+- [Référence de configuration](../../reference/configuration.md) — Configurer la base de données et l'authentification via les variables d'environnement

--- a/docs/ja/explanation/design-philosophy.md
+++ b/docs/ja/explanation/design-philosophy.md
@@ -58,11 +58,11 @@ UseCase は HTTP・DB から独立しているため、MCP ツールとして直
 
 設計の個別決定は ADR に記録されています:
 
-- [ADR-0001: ツールチェーン](../adr/0001-toolchain.md)
-- [ADR-0002: クリーンアーキテクチャ](../adr/0002-clean-architecture.md)
-- [ADR-0003: セキュリティファースト](../adr/0003-security-first.md)
-- [ADR-0004: AI ファースト設計](../adr/0004-ai-first-design.md)
-- [ADR-0005: ロギング](../adr/0005-logging.md)
-- [ADR-0006: レートリミット](../adr/0006-rate-limiting.md)
-- [ADR-0009: MCP 設計](../adr/0009-mcp-design.md)
-- [ADR-0010: AsyncUseCase パターン](../adr/0010-async-use-case.md)
+- [ADR-0001: ツールチェーン](../../adr/0001-toolchain.md)
+- [ADR-0002: クリーンアーキテクチャ](../../adr/0002-clean-architecture.md)
+- [ADR-0003: セキュリティファースト](../../adr/0003-security-first.md)
+- [ADR-0004: AI ファースト設計](../../adr/0004-ai-first-design.md)
+- [ADR-0005: ロギング](../../adr/0005-logging.md)
+- [ADR-0006: レートリミット](../../adr/0006-rate-limiting.md)
+- [ADR-0009: MCP 設計](../../adr/0009-mcp-design.md)
+- [ADR-0010: AsyncUseCase パターン](../../adr/0010-async-use-case.md)

--- a/docs/pt-br/tutorials/getting-started.md
+++ b/docs/pt-br/tutorials/getting-started.md
@@ -51,4 +51,4 @@ Mais de 167 testes devem passar com sucesso.
 
 ## Próximos passos
 
-- [Referência de configuração](../reference/configuration.md) — Configurar banco de dados e autenticação via variáveis de ambiente
+- [Referência de configuração](../../reference/configuration.md) — Configurar banco de dados e autenticação via variáveis de ambiente

--- a/docs/zh/tutorials/getting-started.md
+++ b/docs/zh/tutorials/getting-started.md
@@ -51,4 +51,4 @@ uv run pytest
 
 ## 下一步
 
-- [配置参考](../reference/configuration.md) — 通过环境变量配置数据库和身份验证
+- [配置参考](../../reference/configuration.md) — 通过环境变量配置数据库和身份验证


### PR DESCRIPTION
## Summary

3回目の確認で発見した残存リンク問題を修正。

### ブロークンリンク（4件）

DE/FR/ZH/PT-BR の `getting-started.md` が `../reference/configuration.md` にリンクしていたが、これは `docs/{lang}/reference/configuration.md` を指す（存在しない）。正しくは EN 版の `../../reference/configuration.md`。

| ファイル | 修正前 | 修正後 |
|---|---|---|
| `de/tutorials/getting-started.md` | `../reference/...` | `../../reference/...` |
| `fr/tutorials/getting-started.md` | `../reference/...` | `../../reference/...` |
| `zh/tutorials/getting-started.md` | `../reference/...` | `../../reference/...` |
| `pt-br/tutorials/getting-started.md` | `../reference/...` | `../../reference/...` |

### ADR リンク形式の不整合（2件）

- EN 版 `explanation/design-philosophy.md`: `.md` 拡張子なし → `.md` あり に統一
- JA 版 `ja/explanation/design-philosophy.md`: `../adr/` → `../../adr/` （`docs/ja/explanation/` から `../adr/` は存在しない `docs/ja/adr/` を指していた）

## Test plan

- [x] Python スクリプトで内部リンクを全件検証（型引数の false positive を除き全有効）
- [x] ドキュメントのみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)