### PR TITLE
docs: framework-modules リファレンスに公開APIの未記載エントリを追加

### DIFF
--- a/docs/ja/reference/framework-modules.md
+++ b/docs/ja/reference/framework-modules.md
@@ -39,6 +39,25 @@ from nene2.http import problem_details_response
 return problem_details_response("not-found", "Not Found", 404, "Note 42 not found.")
 ```
 
+### `PaginationQuery`
+
+`PaginationQueryParser.parse()` が返すデータクラス。`limit: int` と `offset: int` を持ちます。
+
+### `HealthCheckProtocol` / `HealthStatus`
+
+ヘルスチェックの契約と結果型。
+
+```python
+from nene2.http import HealthCheckProtocol, HealthStatus
+
+class MyHealthCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="ok")
+```
+
+`HealthStatus` フィールド: `status: str`（`"ok"` または `"error"`）、`checks: dict[str, str]`。
+`is_healthy` プロパティは `status == "ok"` のとき `True`。
+
 ---
 
 ## nene2.use_case
@@ -283,6 +302,24 @@ class TransferUseCase:
 
 詳細なパターンと InMemory テスト実装は [sqlalchemy-repository.md](../how-to/sqlalchemy-repository.md) を参照してください。
 
+### `DatabaseHealthCheck`
+
+`HealthCheckProtocol` を実装し、DB 接続を確認して `HealthStatus` を返します。
+
+```python
+from nene2.database import DatabaseHealthCheck
+from nene2.http import HealthStatus
+
+health = DatabaseHealthCheck(engine)
+status: HealthStatus = health.check()
+# status.status → "ok" または "error"
+# status.checks → {"db": "ok"} または {"db": "error: <message>"}
+```
+
+### `DatabaseConnectionException`
+
+DB 接続不能時に `DatabaseHealthCheck` やリポジトリ操作から raise されます。
+
 ---
 
 ## nene2.mcp
@@ -312,7 +349,18 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
+response.body              # dict | list — パース済み JSON
+response.status_code       # int
 ```
+
+### `McpHttpResponse`
+
+`HttpxMcpClient` メソッドの戻り値型。フィールド: `status_code: int`、`body: dict | list`。
+メソッド: `is_successful() -> bool`（`200 ≤ status_code < 300` のとき `True`）。
+
+### `McpHttpClientProtocol`
+
+カスタム MCP HTTP クライアントの構造的契約。`get()`・`post()`・`put()`・`delete()` を実装して `McpHttpResponse` を返します。
 
 ---
 

--- a/docs/reference/framework-modules.md
+++ b/docs/reference/framework-modules.md
@@ -39,6 +39,25 @@ from nene2.http import problem_details_response
 return problem_details_response("not-found", "Not Found", 404, "Note 42 not found.")
 ```
 
+### `PaginationQuery`
+
+Dataclass returned by `PaginationQueryParser.parse()`. Contains `limit: int` and `offset: int`.
+
+### `HealthCheckProtocol` / `HealthStatus`
+
+Contract and result type for application health checks.
+
+```python
+from nene2.http import HealthCheckProtocol, HealthStatus
+
+class MyHealthCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="ok")
+```
+
+`HealthStatus` fields: `status: str` (`"ok"` or `"error"`), `checks: dict[str, str]`.
+`is_healthy` property returns `True` when `status == "ok"`.
+
 ---
 
 ## nene2.use_case
@@ -328,6 +347,24 @@ class TransferUseCase:
 
 **Testing with InMemory:** Implement `DatabaseTransactionManagerInterface` with a no-op executor that calls the callback directly. The `_in_tx` methods on the InMemory repository ignore the executor and operate on their in-memory store.
 
+### `DatabaseHealthCheck`
+
+Implements `HealthCheckProtocol` — verifies the database connection and returns a `HealthStatus`.
+
+```python
+from nene2.database import DatabaseHealthCheck
+from nene2.http import HealthStatus
+
+health = DatabaseHealthCheck(engine)
+status: HealthStatus = health.check()
+# status.status → "ok" or "error"
+# status.checks → {"db": "ok"} or {"db": "error: <message>"}
+```
+
+### `DatabaseConnectionException`
+
+Raised by `DatabaseHealthCheck` or repository operations when the database is unreachable.
+
 ---
 
 ## nene2.mcp
@@ -357,7 +394,17 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
+response.body              # dict | list — parsed JSON
+response.status_code       # int
 ```
+
+### `McpHttpResponse`
+
+Return type of `HttpxMcpClient` methods. Fields: `status_code: int`, `body: dict | list`. Method: `is_successful() -> bool` (`True` when `200 ≤ status_code < 300`).
+
+### `McpHttpClientProtocol`
+
+Structural contract for custom MCP HTTP clients. Implement `get()`, `post()`, `put()`, `delete()` returning `McpHttpResponse`.
 
 ---
 


### PR DESCRIPTION
## Summary

`__all__` に含まれているが `framework-modules.md` に記載されていなかった公開 API を EN/JA 両版に追加。

### 追加した API（6種類）

| モジュール | クラス/型 | 説明 |
|---|---|---|
| `nene2.http` | `PaginationQuery` | `PaginationQueryParser.parse()` の戻り値型 |
| `nene2.http` | `HealthCheckProtocol` / `HealthStatus` | ヘルスチェックの契約と結果型 |
| `nene2.database` | `DatabaseHealthCheck` | `HealthCheckProtocol` 実装・DB 接続確認 |
| `nene2.database` | `DatabaseConnectionException` | DB 接続不能時の例外 |
| `nene2.mcp` | `McpHttpResponse` | `HttpxMcpClient` の戻り値型 |
| `nene2.mcp` | `McpHttpClientProtocol` | カスタム MCP HTTP クライアントの構造的契約 |

## Test plan

- [x] 全内部リンクをスクリプトで検証 — 問題なし
- [x] ドキュメントのみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)