### PR TITLE
docs: McpHttpResponse の body 型誤記を修正 (#107)

### DIFF
--- a/docs/ja/reference/framework-modules.md
+++ b/docs/ja/reference/framework-modules.md
@@ -39,6 +39,25 @@ from nene2.http import problem_details_response
 return problem_details_response("not-found", "Not Found", 404, "Note 42 not found.")
 ```
 
+### `PaginationQuery`
+
+`PaginationQueryParser.parse()` が返すデータクラス。`limit: int` と `offset: int` を持ちます。
+
+### `HealthCheckProtocol` / `HealthStatus`
+
+ヘルスチェックの契約と結果型。
+
+```python
+from nene2.http import HealthCheckProtocol, HealthStatus
+
+class MyHealthCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="ok")
+```
+
+`HealthStatus` フィールド: `status: str`（`"ok"` または `"error"`）、`checks: dict[str, str]`。
+`is_healthy` プロパティは `status == "ok"` のとき `True`。
+
 ---
 
 ## nene2.use_case
@@ -283,6 +302,24 @@ class TransferUseCase:
 
 詳細なパターンと InMemory テスト実装は [sqlalchemy-repository.md](../how-to/sqlalchemy-repository.md) を参照してください。
 
+### `DatabaseHealthCheck`
+
+`HealthCheckProtocol` を実装し、DB 接続を確認して `HealthStatus` を返します。
+
+```python
+from nene2.database import DatabaseHealthCheck
+from nene2.http import HealthStatus
+
+health = DatabaseHealthCheck(engine)
+status: HealthStatus = health.check()
+# status.status → "ok" または "error"
+# status.checks → {"db": "ok"} または {"db": "error: <message>"}
+```
+
+### `DatabaseConnectionException`
+
+DB 接続不能時に `DatabaseHealthCheck` やリポジトリ操作から raise されます。
+
 ---
 
 ## nene2.mcp
@@ -312,7 +349,18 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
+response.body              # dict | list — パース済み JSON
+response.status_code       # int
 ```
+
+### `McpHttpResponse`
+
+`HttpxMcpClient` メソッドの戻り値型。フィールド: `status_code: int`、`body: dict | list`。
+メソッド: `is_successful() -> bool`（`200 ≤ status_code < 300` のとき `True`）。
+
+### `McpHttpClientProtocol`
+
+カスタム MCP HTTP クライアントの構造的契約。`get()`・`post()`・`put()`・`delete()` を実装して `McpHttpResponse` を返します。
 
 ---
 

--- a/docs/ja/reference/framework-modules.md
+++ b/docs/ja/reference/framework-modules.md
@@ -349,18 +349,24 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
-response.body              # dict | list — パース済み JSON
+response.body              # str — 生のレスポンステキスト
 response.status_code       # int
+response.request_id()      # str | None — X-Request-ID ヘッダーの値
 ```
 
 ### `McpHttpResponse`
 
-`HttpxMcpClient` メソッドの戻り値型。フィールド: `status_code: int`、`body: dict | list`。
-メソッド: `is_successful() -> bool`（`200 ≤ status_code < 300` のとき `True`）。
+`HttpxMcpClient` メソッドの戻り値型。
+
+フィールド: `status_code: int`、`headers: dict[str, str]`、`body: str`（生のレスポンステキスト）。
+
+メソッド:
+- `is_successful() -> bool`（`200 ≤ status_code < 300` のとき `True`）
+- `request_id() -> str | None` — `X-Request-ID` レスポンスヘッダーの値を返す（なければ `None`）
 
 ### `McpHttpClientProtocol`
 
-カスタム MCP HTTP クライアントの構造的契約。`get()`・`post()`・`put()`・`delete()` を実装して `McpHttpResponse` を返します。
+カスタム MCP HTTP クライアントの構造的契約。`get()`・`post()`・`put()`・`delete()` で `McpHttpResponse` を返し、`has_authentication() -> bool` を実装します。
 
 ---
 

--- a/docs/reference/framework-modules.md
+++ b/docs/reference/framework-modules.md
@@ -39,6 +39,25 @@ from nene2.http import problem_details_response
 return problem_details_response("not-found", "Not Found", 404, "Note 42 not found.")
 ```
 
+### `PaginationQuery`
+
+Dataclass returned by `PaginationQueryParser.parse()`. Contains `limit: int` and `offset: int`.
+
+### `HealthCheckProtocol` / `HealthStatus`
+
+Contract and result type for application health checks.
+
+```python
+from nene2.http import HealthCheckProtocol, HealthStatus
+
+class MyHealthCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="ok")
+```
+
+`HealthStatus` fields: `status: str` (`"ok"` or `"error"`), `checks: dict[str, str]`.
+`is_healthy` property returns `True` when `status == "ok"`.
+
 ---
 
 ## nene2.use_case
@@ -328,6 +347,24 @@ class TransferUseCase:
 
 **Testing with InMemory:** Implement `DatabaseTransactionManagerInterface` with a no-op executor that calls the callback directly. The `_in_tx` methods on the InMemory repository ignore the executor and operate on their in-memory store.
 
+### `DatabaseHealthCheck`
+
+Implements `HealthCheckProtocol` — verifies the database connection and returns a `HealthStatus`.
+
+```python
+from nene2.database import DatabaseHealthCheck
+from nene2.http import HealthStatus
+
+health = DatabaseHealthCheck(engine)
+status: HealthStatus = health.check()
+# status.status → "ok" or "error"
+# status.checks → {"db": "ok"} or {"db": "error: <message>"}
+```
+
+### `DatabaseConnectionException`
+
+Raised by `DatabaseHealthCheck` or repository operations when the database is unreachable.
+
 ---
 
 ## nene2.mcp
@@ -357,7 +394,17 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
+response.body              # dict | list — parsed JSON
+response.status_code       # int
 ```
+
+### `McpHttpResponse`
+
+Return type of `HttpxMcpClient` methods. Fields: `status_code: int`, `body: dict | list`. Method: `is_successful() -> bool` (`True` when `200 ≤ status_code < 300`).
+
+### `McpHttpClientProtocol`
+
+Structural contract for custom MCP HTTP clients. Implement `get()`, `post()`, `put()`, `delete()` returning `McpHttpResponse`.
 
 ---
 

--- a/docs/reference/framework-modules.md
+++ b/docs/reference/framework-modules.md
@@ -394,17 +394,24 @@ from nene2.mcp import HttpxMcpClient
 client = HttpxMcpClient("bearer-token")
 response = client.get("http://localhost:8080", "/notes")
 response.is_successful()   # True
-response.body              # dict | list — parsed JSON
+response.body              # str — raw response text
 response.status_code       # int
+response.request_id()      # str | None — value of X-Request-ID header
 ```
 
 ### `McpHttpResponse`
 
-Return type of `HttpxMcpClient` methods. Fields: `status_code: int`, `body: dict | list`. Method: `is_successful() -> bool` (`True` when `200 ≤ status_code < 300`).
+Return type of `HttpxMcpClient` methods.
+
+Fields: `status_code: int`, `headers: dict[str, str]`, `body: str` (raw response text).
+
+Methods:
+- `is_successful() -> bool` — `True` when `200 ≤ status_code < 300`
+- `request_id() -> str | None` — returns the `X-Request-ID` response header value, or `None`
 
 ### `McpHttpClientProtocol`
 
-Structural contract for custom MCP HTTP clients. Implement `get()`, `post()`, `put()`, `delete()` returning `McpHttpResponse`.
+Structural contract for custom MCP HTTP clients. Implement `get()`, `post()`, `put()`, `delete()` returning `McpHttpResponse`, and `has_authentication() -> bool`.
 
 ---
 


### PR DESCRIPTION
## Summary

- PR #106 で導入した `McpHttpResponse` のドキュメント記述を実装に合わせて修正
- `body: dict | list` (誤) → `body: str` 生のレスポンステキスト (正)
- 欠落していた `headers: dict[str, str]` フィールドと `request_id()` メソッドを追記
- `McpHttpClientProtocol` に `has_authentication()` を追記
- EN / JA 両版に適用

Closes #107

## Test plan

- [ ] `docs/reference/framework-modules.md` の McpHttpResponse セクションが実コード（`src/nene2/mcp/http_client.py`）と一致していることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)