### PR TITLE
fix: note / tag の Input・Output dataclass に slots=True を追加 (#110)

### DIFF
--- a/src/example/note/use_case.py
+++ b/src/example/note/use_case.py
@@ -7,13 +7,13 @@ from .exceptions import NoteNotFoundException
 from .repository import NoteRepositoryInterface
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ListNotesInput:
     limit: int
     offset: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ListNotesOutput:
     items: list[Note]
     limit: int
@@ -36,7 +36,7 @@ class ListNotesUseCase:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CreateNoteInput:
     title: str
     body: str
@@ -61,7 +61,7 @@ class GetNoteUseCase:
         return note
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UpdateNoteInput:
     note_id: int
     title: str
@@ -79,7 +79,7 @@ class UpdateNoteUseCase:
         return note
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DeleteNoteInput:
     note_id: int
 

--- a/src/example/tag/use_case.py
+++ b/src/example/tag/use_case.py
@@ -7,13 +7,13 @@ from .exceptions import TagNotFoundException
 from .repository import TagRepositoryInterface
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ListTagsInput:
     limit: int
     offset: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ListTagsOutput:
     items: list[Tag]
     limit: int
@@ -47,7 +47,7 @@ class GetTagUseCase:
         return tag
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CreateTagInput:
     name: str
 
@@ -60,7 +60,7 @@ class CreateTagUseCase:
         return self._repository.save(input_.name)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UpdateTagInput:
     tag_id: int
     name: str
@@ -77,7 +77,7 @@ class UpdateTagUseCase:
         return tag
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DeleteTagInput:
     tag_id: int
 


### PR DESCRIPTION
## Summary

- CLAUDE.md 規約「`dataclass(frozen=True, slots=True)` で immutable value object」に合わせて修正
- `src/example/note/use_case.py`: `ListNotesInput/Output`, `CreateNoteInput`, `UpdateNoteInput`, `DeleteNoteInput` に `slots=True` を追加
- `src/example/tag/use_case.py`: 同様の Input/Output dataclass に `slots=True` を追加
- `src/example/comment/use_case.py` はすでに準拠済みのため変更なし

Closes #110

## Test plan

- [ ] `uv run pytest` が全パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)