### PR TITLE
fix(#121): ApiKeyAuthMiddleware で TokenVerificationException を 401 に変換する

### DIFF
--- a/src/nene2/auth/api_key.py
+++ b/src/nene2/auth/api_key.py
@@ -10,9 +10,17 @@ from starlette.responses import Response
 
 from nene2.http.problem_details import problem_details_response
 
+from .exceptions import TokenVerificationException
 from .interfaces import TokenVerifierProtocol
 
 _API_KEY_HEADER = "X-Api-Key"
+
+_UNAUTHORIZED = problem_details_response(
+    "unauthorized",
+    "Unauthorized",
+    401,
+    "A valid X-Api-Key header is required.",
+)
 
 
 class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
@@ -24,11 +32,10 @@ class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         api_key = request.headers.get(_API_KEY_HEADER, "")
-        if not api_key or not self._verifier.verify(api_key):
-            return problem_details_response(
-                "unauthorized",
-                "Unauthorized",
-                401,
-                "A valid X-Api-Key header is required.",
-            )
+        try:
+            verified = bool(api_key) and self._verifier.verify(api_key)
+        except TokenVerificationException:
+            verified = False
+        if not verified:
+            return _UNAUTHORIZED
         return await call_next(request)

--- a/tests/nene2/auth/test_api_key.py
+++ b/tests/nene2/auth/test_api_key.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from nene2.auth import ApiKeyAuthMiddleware, LocalTokenVerifier
+from nene2.auth.exceptions import TokenVerificationException
 
 
 def _make_app(keys: list[str]) -> FastAPI:
@@ -43,3 +44,25 @@ def test_multiple_allowed_keys() -> None:
     assert client.get("/secret", headers={"X-Api-Key": "key-a"}).status_code == 200
     assert client.get("/secret", headers={"X-Api-Key": "key-b"}).status_code == 200
     assert client.get("/secret", headers={"X-Api-Key": "key-c"}).status_code == 401
+
+
+def test_verifier_raises_token_verification_exception_returns_401() -> None:
+    """TokenVerificationException from verifier must return 401, not 500."""
+
+    class ExplodingVerifier:
+        def verify(self, token: str) -> bool:
+            raise TokenVerificationException("simulated failure")
+
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=ExplodingVerifier(),  # type: ignore[arg-type]
+    )
+
+    @app.get("/secret")
+    async def secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/secret", headers={"X-Api-Key": "any-key"})
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

- `ApiKeyAuthMiddleware` が `TokenVerificationException` をキャッチしておらず、`BearerTokenMiddleware` と非対称だった
- `try/except TokenVerificationException` を追加し、例外時も 401 を返すよう修正
- `ExplodingVerifier` を使ったテストで 500 → 401 の修正を検証

## Test plan

- [x] 既存の 4 テストが継続パス
- [x] `test_verifier_raises_token_verification_exception_returns_401` — verifier が例外を投げても 401（新規）

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)