### PR TITLE
fix(#125/#126/#127): DatabaseHealthCheck / _BoundQueryExecutor / CORS ヘッダー修正

### DIFF
--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -22,7 +22,12 @@ class AppSettings(BaseSettings):
     cors_origins: list[str] = []
     cors_allow_credentials: bool = False
     cors_allow_methods: list[str] = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
-    cors_allow_headers: list[str] = ["*"]
+    cors_allow_headers: list[str] = [
+        "Content-Type",
+        "Authorization",
+        "X-Api-Key",
+        "X-Request-Id",
+    ]
 
     bearer_token_enabled: bool = False
     bearer_tokens: list[str] = []

--- a/src/nene2/database/health.py
+++ b/src/nene2/database/health.py
@@ -1,8 +1,12 @@
 """Database health check — verifies DB connectivity for /health endpoint."""
 
+import logging
+
 from nene2.http import HealthStatus
 
 from .interfaces import DatabaseQueryExecutorInterface
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseHealthCheck:
@@ -15,5 +19,6 @@ class DatabaseHealthCheck:
         try:
             self._executor.fetch_one("SELECT 1 AS ok")
             return HealthStatus(status="ok", checks={"database": "ok"})
-        except Exception:
-            return HealthStatus(status="degraded", checks={"database": "error"})
+        except Exception as exc:
+            logger.warning("database health check failed: %s", exc)
+            return HealthStatus(status="error", checks={"database": "error"})

--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -65,17 +65,26 @@ class _BoundQueryExecutor(DatabaseQueryExecutorInterface):
         self._conn = conn
 
     def fetch_all(self, sql: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        result = self._conn.execute(text(sql), params or {})
-        return [dict(row._mapping) for row in result]
+        try:
+            result = self._conn.execute(text(sql), params or {})
+            return [dict(row._mapping) for row in result]
+        except OperationalError as exc:
+            raise DatabaseConnectionException(str(exc)) from exc
 
     def fetch_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        result = self._conn.execute(text(sql), params or {})
-        row = result.fetchone()
-        return dict(row._mapping) if row else None
+        try:
+            result = self._conn.execute(text(sql), params or {})
+            row = result.fetchone()
+            return dict(row._mapping) if row else None
+        except OperationalError as exc:
+            raise DatabaseConnectionException(str(exc)) from exc
 
     def write(self, sql: str, params: dict[str, Any] | None = None) -> int:
-        result = self._conn.execute(text(sql), params or {})
-        return result.lastrowid or result.rowcount
+        try:
+            result = self._conn.execute(text(sql), params or {})
+            return result.lastrowid or result.rowcount
+        except OperationalError as exc:
+            raise DatabaseConnectionException(str(exc)) from exc
 
 
 class SqlAlchemyTransactionManager(DatabaseTransactionManagerInterface):


### PR DESCRIPTION
## Summary

### #125 — DatabaseHealthCheck: bare except + 未文書 'degraded' ステータス
- `except Exception:` → `except Exception as exc:` に変更し `logger.warning` でエラーを記録
- `status="degraded"` → `status="error"` に統一（ドキュメントの `ok | error` 契約を守る）

### #126 — `_BoundQueryExecutor`: OperationalError 未処理
- `fetch_all`, `fetch_one`, `write` の全メソッドに `except OperationalError → DatabaseConnectionException` を追加
- `SqlAlchemyQueryExecutor` と対称な実装に揃える

### #127 — `cors_allow_headers` のワイルドカードデフォルト
- `["*"]` → `["Content-Type", "Authorization", "X-Api-Key", "X-Request-Id"]` に変更
- CLAUDE.md の `allow_origins` ワイルドカード禁止ポリシーと整合させる

## Test plan

- [x] 全 102 テスト継続パス

Closes #125
Closes #126
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)