### PR TITLE
fix(#128/#129/#130/#131/#132): 低優先度バグ・コード品質の一括修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/example/comment/repository.py
+++ b/src/example/comment/repository.py
@@ -31,7 +31,9 @@ class InMemoryCommentRepository(CommentRepositoryInterface):
         self._next_id = 1
 
     def find_all_by_note(self, note_id: int, limit: int, offset: int) -> list[Comment]:
-        items = [c for c in self._store.values() if c.note_id == note_id]
+        items = sorted(
+            (c for c in self._store.values() if c.note_id == note_id), key=lambda c: c.id
+        )
         return items[offset : offset + limit]
 
     def find_by_id(self, comment_id: int) -> Comment | None:

--- a/src/example/mcp.py
+++ b/src/example/mcp.py
@@ -74,70 +74,70 @@ def create_mcp_server(settings: AppSettings | None = None) -> LocalMcpServer:
     )
 
     @server.tool("List notes with optional pagination.")
-    def list_notes(limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]
+    def list_notes(limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         result = note_list.execute(ListNotesInput(limit=limit, offset=offset))
         return [asdict(n) for n in result.items]
 
     @server.tool("Get a single note by ID.")
-    def get_note(note_id: int) -> dict:  # type: ignore[type-arg]
+    def get_note(note_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(note_get.execute(note_id))
 
     @server.tool("Create a new note.")
-    def create_note(title: str, body: str) -> dict:  # type: ignore[type-arg]
+    def create_note(title: str, body: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(note_create.execute(CreateNoteInput(title=title, body=body)))
 
     @server.tool("Update an existing note.")
-    def update_note(note_id: int, title: str, body: str) -> dict:  # type: ignore[type-arg]
+    def update_note(note_id: int, title: str, body: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(note_update.execute(UpdateNoteInput(note_id=note_id, title=title, body=body)))
 
     @server.tool("Delete a note by ID.")
-    def delete_note(note_id: int) -> dict:  # type: ignore[type-arg]
+    def delete_note(note_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         note_delete.execute(DeleteNoteInput(note_id=note_id))
         return {"deleted": True, "note_id": note_id}
 
     @server.tool("List tags with optional pagination.")
-    def list_tags(limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]
+    def list_tags(limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         result = tag_list.execute(ListTagsInput(limit=limit, offset=offset))
         return [asdict(t) for t in result.items]
 
     @server.tool("Get a single tag by ID.")
-    def get_tag(tag_id: int) -> dict:  # type: ignore[type-arg]
+    def get_tag(tag_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(tag_get.execute(tag_id))
 
     @server.tool("Create a new tag.")
-    def create_tag(name: str) -> dict:  # type: ignore[type-arg]
+    def create_tag(name: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(tag_create.execute(CreateTagInput(name=name)))
 
     @server.tool("Update an existing tag.")
-    def update_tag(tag_id: int, name: str) -> dict:  # type: ignore[type-arg]
+    def update_tag(tag_id: int, name: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(tag_update.execute(UpdateTagInput(tag_id=tag_id, name=name)))
 
     @server.tool("Delete a tag by ID.")
-    def delete_tag(tag_id: int) -> dict:  # type: ignore[type-arg]
+    def delete_tag(tag_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         tag_delete.execute(DeleteTagInput(tag_id=tag_id))
         return {"deleted": True, "tag_id": tag_id}
 
     @server.tool("List comments for a note.")
-    def list_comments(note_id: int, limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]
+    def list_comments(note_id: int, limit: int = 20, offset: int = 0) -> list[dict]:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         result = comment_list.execute(
             ListCommentsInput(note_id=note_id, limit=limit, offset=offset)
         )
         return [asdict(c) for c in result.items]
 
     @server.tool("Get a single comment by ID.")
-    def get_comment(comment_id: int) -> dict:  # type: ignore[type-arg]
+    def get_comment(comment_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(comment_get.execute(comment_id))
 
     @server.tool("Create a new comment on a note.")
-    def create_comment(note_id: int, body: str) -> dict:  # type: ignore[type-arg]
+    def create_comment(note_id: int, body: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(comment_create.execute(CreateCommentInput(note_id=note_id, body=body)))
 
     @server.tool("Update an existing comment.")
-    def update_comment(comment_id: int, body: str) -> dict:  # type: ignore[type-arg]
+    def update_comment(comment_id: int, body: str) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         return asdict(comment_update.execute(UpdateCommentInput(comment_id=comment_id, body=body)))
 
     @server.tool("Delete a comment by ID.")
-    def delete_comment(comment_id: int) -> dict:  # type: ignore[type-arg]
+    def delete_comment(comment_id: int) -> dict:  # type: ignore[type-arg]  # reason: mcp tool handler type stubs do not support generic dict
         comment_delete.execute(DeleteCommentInput(comment_id=comment_id))
         return {"deleted": True, "comment_id": comment_id}
 

--- a/src/nene2/config/settings.py
+++ b/src/nene2/config/settings.py
@@ -37,6 +37,14 @@ class AppSettings(BaseSettings):
     db_user: str = ""
     db_password: SecretStr = SecretStr("")
 
+    @field_validator("app_env")
+    @classmethod
+    def validate_app_env(cls, v: str) -> str:
+        allowed = {"local", "test", "production"}
+        if v not in allowed:
+            raise ValueError(f"app_env must be one of {allowed}")
+        return v
+
     @field_validator("db_adapter")
     @classmethod
     def validate_adapter(cls, v: str) -> str:

--- a/src/scripts/export_openapi.py
+++ b/src/scripts/export_openapi.py
@@ -1,8 +1,7 @@
 """Export the FastAPI OpenAPI schema to docs/openapi.yaml.
 
 Usage:
-  uv run export-openapi
-  python scripts/export_openapi.py
+  uv run python src/scripts/export_openapi.py
 """
 
 import json


### PR DESCRIPTION
## Summary

### #128 — InMemoryCommentRepository ソート欠如
- `find_all_by_note()` に `sorted(..., key=lambda c: c.id)` を追加
- `SqlAlchemyCommentRepository` の `ORDER BY id` と挙動を一致させる

### #129 — mcp.py の type: ignore に reason コメントがない
- 15 件の `# type: ignore[type-arg]` 全てに `# reason: mcp tool handler type stubs do not support generic dict` を追加

### #130 — app_env が未検証
- `@field_validator("app_env")` で `{"local", "test", "production"}` に制限
- タイポで本番ログ設定が変わるリスクを排除

### #131 — CI Python matrix に 3.14 がない
- `["3.12", "3.14"]` に拡張（CLAUDE.md 記載の開発環境 3.14 と一致）

### #132 — export_openapi.py の stale docstring
- 削除済みの `uv run export-openapi` → 正しい `uv run python src/scripts/export_openapi.py` に修正

## Test plan

- [x] 167 テスト全パス
- [x] mypy --strict パス
- [x] ruff check パス

Closes #128
Closes #129
Closes #130
Closes #131
Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)