### PR TITLE
fix: Note entity に slots=True を追加（#140）

### DIFF
--- a/src/example/note/entity.py
+++ b/src/example/note/entity.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Note:
     id: int
     title: str


### PR DESCRIPTION
## Summary

- `src/example/note/entity.py` の `Note` dataclass に `slots=True` を追加
- `Tag` / `Comment` entity との一貫性を回復、CLAUDE.md の規約準拠

## 変更内容

```python
# before
@dataclass(frozen=True)
class Note:

# after
@dataclass(frozen=True, slots=True)
class Note:
```

## Background

2026-05-20 の包括的評価レポートで指摘。13 件の既存 PR (Issue #107〜#132) は
use_case.py の Input DTO を対象とした Issue #110 で対応済みだが、
`note/entity.py` 本体は抜け落ちていた。

## Test plan

- [x] `uv run pytest` — 167 tests passed, 91.77% coverage
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)