### PR TITLE
fix: GetNote/GetTag typed Input DTO 統一 + _BoundQueryExecutor TRY300 修正

### DIFF
--- a/src/example/mcp.py
+++ b/src/example/mcp.py
@@ -27,6 +27,7 @@ from .note.use_case import (
     CreateNoteUseCase,
     DeleteNoteInput,
     DeleteNoteUseCase,
+    GetNoteInput,
     GetNoteUseCase,
     ListNotesInput,
     ListNotesUseCase,
@@ -38,6 +39,7 @@ from .tag.use_case import (
     CreateTagUseCase,
     DeleteTagInput,
     DeleteTagUseCase,
+    GetTagInput,
     GetTagUseCase,
     ListTagsInput,
     ListTagsUseCase,
@@ -81,7 +83,7 @@ def create_mcp_server(settings: AppSettings | None = None) -> LocalMcpServer:
 
     @server.tool("Get a single note by ID.")
     def get_note(note_id: int) -> dict:  # type: ignore[type-arg]
-        return asdict(note_get.execute(note_id))
+        return asdict(note_get.execute(GetNoteInput(note_id=note_id)))
 
     @server.tool("Create a new note.")
     def create_note(title: str, body: str) -> dict:  # type: ignore[type-arg]
@@ -103,7 +105,7 @@ def create_mcp_server(settings: AppSettings | None = None) -> LocalMcpServer:
 
     @server.tool("Get a single tag by ID.")
     def get_tag(tag_id: int) -> dict:  # type: ignore[type-arg]
-        return asdict(tag_get.execute(tag_id))
+        return asdict(tag_get.execute(GetTagInput(tag_id=tag_id)))
 
     @server.tool("Create a new tag.")
     def create_tag(name: str) -> dict:  # type: ignore[type-arg]

--- a/src/example/note/handler.py
+++ b/src/example/note/handler.py
@@ -12,6 +12,7 @@ from .use_case import (
     CreateNoteUseCase,
     DeleteNoteInput,
     DeleteNoteUseCase,
+    GetNoteInput,
     GetNoteUseCase,
     ListNotesInput,
     ListNotesUseCase,
@@ -54,7 +55,7 @@ def make_note_router(
 
     @router.get("/{note_id}")
     async def get_note(note_id: int) -> JSONResponse:
-        note = get_use_case.execute(note_id)
+        note = get_use_case.execute(GetNoteInput(note_id))
         return JSONResponse({"id": note.id, "title": note.title, "body": note.body})
 
     @router.post("", status_code=201)

--- a/src/example/note/use_case.py
+++ b/src/example/note/use_case.py
@@ -50,14 +50,19 @@ class CreateNoteUseCase:
         return self._repository.save(input_.title, input_.body)
 
 
+@dataclass(frozen=True, slots=True)
+class GetNoteInput:
+    note_id: int
+
+
 class GetNoteUseCase:
     def __init__(self, repository: NoteRepositoryInterface) -> None:
         self._repository = repository
 
-    def execute(self, note_id: int) -> Note:
-        note = self._repository.find_by_id(note_id)
+    def execute(self, input_: GetNoteInput) -> Note:
+        note = self._repository.find_by_id(input_.note_id)
         if note is None:
-            raise NoteNotFoundException(note_id)
+            raise NoteNotFoundException(input_.note_id)
         return note
 
 

--- a/src/example/tag/handler.py
+++ b/src/example/tag/handler.py
@@ -12,6 +12,7 @@ from .use_case import (
     CreateTagUseCase,
     DeleteTagInput,
     DeleteTagUseCase,
+    GetTagInput,
     GetTagUseCase,
     ListTagsInput,
     ListTagsUseCase,
@@ -52,7 +53,7 @@ def make_tag_router(
 
     @router.get("/{tag_id}")
     async def get_tag(tag_id: int) -> JSONResponse:
-        tag = get_use_case.execute(tag_id)
+        tag = get_use_case.execute(GetTagInput(tag_id))
         return JSONResponse({"id": tag.id, "name": tag.name})
 
     @router.post("", status_code=201)

--- a/src/example/tag/use_case.py
+++ b/src/example/tag/use_case.py
@@ -36,14 +36,19 @@ class ListTagsUseCase:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class GetTagInput:
+    tag_id: int
+
+
 class GetTagUseCase:
     def __init__(self, repository: TagRepositoryInterface) -> None:
         self._repository = repository
 
-    def execute(self, tag_id: int) -> Tag:
-        tag = self._repository.find_by_id(tag_id)
+    def execute(self, input_: GetTagInput) -> Tag:
+        tag = self._repository.find_by_id(input_.tag_id)
         if tag is None:
-            raise TagNotFoundException(tag_id)
+            raise TagNotFoundException(input_.tag_id)
         return tag
 
 

--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -82,9 +82,9 @@ class _BoundQueryExecutor(DatabaseQueryExecutorInterface):
     def write(self, sql: str, params: dict[str, Any] | None = None) -> int:
         try:
             result = self._conn.execute(text(sql), params or {})
-            return result.lastrowid or result.rowcount
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
+        return result.lastrowid or result.rowcount
 
 
 class SqlAlchemyTransactionManager(DatabaseTransactionManagerInterface):

--- a/tests/example/comment/test_comment_http.py
+++ b/tests/example/comment/test_comment_http.py
@@ -56,9 +56,7 @@ def test_get_comment_not_found() -> None:
 def test_update_comment() -> None:
     client, note_id = _client_with_note()
     created = client.post(f"/notes/{note_id}/comments", json={"body": "original"}).json()
-    response = client.put(
-        f"/notes/{note_id}/comments/{created['id']}", json={"body": "updated"}
-    )
+    response = client.put(f"/notes/{note_id}/comments/{created['id']}", json={"body": "updated"})
     assert response.status_code == 200
     assert response.json()["body"] == "updated"
 

--- a/tests/example/test_mcp.py
+++ b/tests/example/test_mcp.py
@@ -11,6 +11,7 @@ from example.note.use_case import (
     CreateNoteUseCase,
     DeleteNoteInput,
     DeleteNoteUseCase,
+    GetNoteInput,
     GetNoteUseCase,
     ListNotesInput,
     ListNotesUseCase,
@@ -44,7 +45,7 @@ def test_note_lifecycle_via_use_cases() -> None:
 
     note = create_uc.execute(CreateNoteInput(title="MCP note", body="content"))
     assert list_uc.execute(ListNotesInput(limit=10, offset=0)).total == 1
-    fetched = get_uc.execute(note.id)
+    fetched = get_uc.execute(GetNoteInput(note_id=note.id))
     assert fetched.title == "MCP note"
     delete_uc.execute(DeleteNoteInput(note_id=note.id))
     assert list_uc.execute(ListNotesInput(limit=10, offset=0)).total == 0

--- a/tests/nene2/middleware/test_request_id.py
+++ b/tests/nene2/middleware/test_request_id.py
@@ -8,9 +8,7 @@ from fastapi.testclient import TestClient
 
 from nene2.middleware import RequestIdMiddleware, request_id_var
 
-_UUID_V4_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-)
+_UUID_V4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 
 
 def _make_app() -> FastAPI:


### PR DESCRIPTION
## Summary

- PR #118 が merge conflict により自動マージ不可だったため手動適用
- PR #136 で `GetCommentInput` は適用済みのため Note/Tag のみ対応
- `GetNoteInput` / `GetTagInput` を追加し、対応する UseCase・Handler・MCP を更新
- 合わせて `_BoundQueryExecutor.write()` の TRY300 違反（`return` inside `try`）を修正

## Changes

| ファイル | 変更内容 |
|---|---|
| `note/use_case.py` | `GetNoteInput` 追加、`GetNoteUseCase.execute` 型変更 |
| `tag/use_case.py` | `GetTagInput` 追加、`GetTagUseCase.execute` 型変更 |
| `note/handler.py` | `GetNoteInput` インポート・使用 |
| `tag/handler.py` | `GetTagInput` インポート・使用 |
| `mcp.py` | `GetNoteInput`/`GetTagInput` インポート・使用 |
| `sqlalchemy_executor.py` | `_BoundQueryExecutor.write` TRY300 修正 |
| `tests/example/test_mcp.py` | `GetNoteInput` 使用に更新 |

## Test plan

- [x] `uv run pytest` — 178 tests passed, 91.32% coverage
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)