### PR TITLE
fix(#148): ミドルウェア登録順を修正し CORS を最外側に配置

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -110,35 +110,8 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
-    if cfg.api_key_enabled:
-        app.add_middleware(
-            ApiKeyAuthMiddleware,
-            verifier=LocalTokenVerifier(cfg.api_keys),
-        )
-    if cfg.bearer_token_enabled:
-        app.add_middleware(
-            BearerTokenMiddleware,
-            verifier=LocalTokenVerifier(cfg.bearer_tokens),
-        )
-    if cfg.cors_enabled:
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=cfg.cors_origins,
-            allow_credentials=cfg.cors_allow_credentials,
-            allow_methods=cfg.cors_allow_methods,
-            allow_headers=cfg.cors_allow_headers,
-        )
-    if cfg.throttle_enabled:
-        app.add_middleware(
-            ThrottleMiddleware,
-            limit=cfg.throttle_limit,
-            window=cfg.throttle_window,
-        )
-    app.add_middleware(RequestSizeLimitMiddleware, max_bytes=cfg.max_body_size)
-    app.add_middleware(RequestLoggingMiddleware)
-    app.add_middleware(RequestIdMiddleware)
-    if cfg.security_headers_enabled:
-        app.add_middleware(SecurityHeadersMiddleware)
+    # Registration order: innermost first, outermost last.
+    # Starlette executes in reverse — the last registered wraps all others.
     app.add_middleware(
         ErrorHandlerMiddleware,
         debug=cfg.app_debug,
@@ -148,6 +121,38 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
             CommentNotFoundExceptionHandler(),
         ],
     )
+    if cfg.security_headers_enabled:
+        app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(RequestIdMiddleware)
+    app.add_middleware(RequestLoggingMiddleware)
+    app.add_middleware(RequestSizeLimitMiddleware, max_bytes=cfg.max_body_size)
+    if cfg.throttle_enabled:
+        app.add_middleware(
+            ThrottleMiddleware,
+            limit=cfg.throttle_limit,
+            window=cfg.throttle_window,
+        )
+    # Auth sits inside the CORS layer so preflight OPTIONS bypasses auth checks.
+    if cfg.bearer_token_enabled:
+        app.add_middleware(
+            BearerTokenMiddleware,
+            verifier=LocalTokenVerifier(cfg.bearer_tokens),
+        )
+    if cfg.api_key_enabled:
+        app.add_middleware(
+            ApiKeyAuthMiddleware,
+            verifier=LocalTokenVerifier(cfg.api_keys),
+        )
+    # CORS must be outermost — register last so preflight OPTIONS is handled
+    # before throttle, auth, or any other middleware runs.
+    if cfg.cors_enabled:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cfg.cors_origins,
+            allow_credentials=cfg.cors_allow_credentials,
+            allow_methods=cfg.cors_allow_methods,
+            allow_headers=cfg.cors_allow_headers,
+        )
     app.add_exception_handler(
         ValidationException,
         ErrorHandlerMiddleware.handle_validation_exception,

--- a/tests/example/test_cors.py
+++ b/tests/example/test_cors.py
@@ -40,3 +40,24 @@ def test_cors_preflight_returns_204() -> None:
     )
     assert response.status_code in (200, 204)
     assert "Access-Control-Allow-Origin" in response.headers
+
+
+def test_cors_preflight_not_blocked_by_throttle() -> None:
+    cfg = AppSettings(
+        cors_enabled=True,
+        cors_origins=["http://localhost:3000"],
+        throttle_enabled=True,
+        throttle_limit=1,
+        throttle_window=60,
+    )
+    client = TestClient(create_app(cfg))
+    headers = {
+        "Origin": "http://localhost:3000",
+        "Access-Control-Request-Method": "GET",
+    }
+    # First request consumes the one allowed slot.
+    client.get("/health", headers={"Origin": "http://localhost:3000"})
+    # Preflight OPTIONS must still succeed even though the rate limit is exhausted.
+    response = client.options("/health", headers=headers)
+    assert response.status_code in (200, 204)
+    assert "Access-Control-Allow-Origin" in response.headers


### PR DESCRIPTION
## Summary

`app.py` のミドルウェア登録順が `docs/reference/framework-modules.md` のドキュメントと乖離しており、CORS が Throttle の内側に配置されていた。

Starlette は `add_middleware()` を逆順で実行するため、**最後に登録したものが最外側**になる。現状では `ErrorHandlerMiddleware` が最後（最外側）に登録されており、`CORSMiddleware` が `ThrottleMiddleware` の内側にある。

このため `cors_enabled=True` かつ `throttle_enabled=True` の環境でブラウザの preflight OPTIONS リクエストがレート制限の対象となり、429 を受け取る可能性があった。

## 変更内容

- `app.py` のミドルウェア登録順をドキュメント通りに修正
  - 変更前: `ApiKey → Bearer → CORS → Throttle → ... → ErrorHandler`（最外側）
  - 変更後: `ErrorHandler → ... → Throttle → Bearer → ApiKey → CORS`（最外側）
- `test_cors.py` に `throttle_limit=1` の状態で preflight OPTIONS が 429 にならないことを確認するテストを追加

## Test plan

- [ ] `uv run pytest` — 181 passed, 91.30% coverage
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check src/ tests/` — All checks passed
- [ ] 新規テスト `test_cors_preflight_not_blocked_by_throttle` が通過することを確認

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)