### PR TITLE
feat(#156): v1.0.0 PyPI 公開準備 — バージョン更新と publish.yml 追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Build
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/nene2-python
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://upload.test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nene2-python
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "0.1.0"
+version = "1.0.0"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` バージョンを `0.1.0` → `1.0.0` に更新
- `.github/workflows/publish.yml` を新規追加（`v*` タグ push でトリガー）
  - Step 1: `uv build` でビルド
  - Step 2: TestPyPI に公開（`testpypi` environment）
  - Step 3: PyPI 本番に公開（`pypi` environment）
  - Step 4: GitHub Release 作成（dist ファイル添付）
  - 認証は OIDC Trusted Publishing（シークレット不要）

## ビルド確認

```
dist/nene2_python-1.0.0.tar.gz
dist/nene2_python-1.0.0-py3-none-any.whl  (40 files, py.typed 含む)
```

## マージ後の手順

1. PyPI / TestPyPI で Trusted Publisher を設定
   - Publisher: `hideyukiMORI/nene2-python`
   - Workflow: `publish.yml`
   - Environment: `testpypi` / `pypi`
2. GitHub repository の `testpypi` / `pypi` environment を作成
3. `git tag v1.0.0 && git push origin v1.0.0` でリリース

## Test plan

- [ ] `uv run pytest` — 180 passed, 91.30% coverage
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check src/ tests/` — All checks passed
- [ ] `uv build` — `nene2_python-1.0.0-py3-none-any.whl` が生成される

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)