### PR TITLE
fix: publish.yml を pypa/gh-action-pypi-publish から uv publish に切り替え

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -43,9 +48,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://upload.test.pypi.org/legacy/
+        run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always
 
   publish-pypi:
     name: Publish to PyPI
@@ -57,6 +60,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -64,7 +72,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish --trusted-publishing always
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## 問題

`pypa/gh-action-pypi-publish@release/v1` は Docker コンテナ内で動作するため、
GitHub Actions の Docker ネットワーク環境で `upload.test.pypi.org` の DNS 解決が
失敗する既知の問題がある（`[Errno -5] No address associated with hostname`）。

## 対応

`uv publish --trusted-publishing always` に切り替え。

- Docker を使わないため DNS 問題が発生しない
- OIDC Trusted Publishing を uv ネイティブでサポート
- TestPyPI は `--publish-url https://test.pypi.org/legacy/` で指定

## 変更点

各 publish job に `astral-sh/setup-uv@v5` を追加し、
`pypa/gh-action-pypi-publish` の uses を `uv publish` の run に置き換え。

🤖 Generated with [Claude Code](https://claude.com/claude-code)