### PR TITLE
feat: publish.yml に PyPI 本番・GitHub Release ジョブを追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,47 @@ jobs:
       - name: Publish to TestPyPI
         run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always
 
-  # PyPI 本番公開は PyPI アカウント登録・Trusted Publisher 設定後に追加する
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nene2-python
+    permissions:
+      id-token: write
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

PyPI アカウント・Trusted Publisher 設定完了に伴い、
`publish-pypi` / `github-release` ジョブを復元。

TestPyPI → PyPI → GitHub Release の順に自動実行される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)