### PR TITLE
fix: FT10 摩擦点の改善（PaginationResponse直列化・PaginationQueryParser Depends対応・MySQL docs）

### DIFF
--- a/docs/field-trials/2026-05-field-trial-10.md
+++ b/docs/field-trials/2026-05-field-trial-10.md
@@ -1,0 +1,167 @@
+# Field Trial 10 — inventory: MySQL アダプター DX 検証
+
+## Date
+
+2026-05-20
+
+## Baseline
+
+- nene2-python v1.2.0（PyPI 経由）
+- Python 3.14（uv managed）
+- プロジェクト: **inventory** — 在庫管理 API
+- エンティティ: `Product(id, name, price, stock, created_at)`
+- HTTP API: ポート 8110（FastAPI + MySQL 8）
+- DB: MySQL 8.0（Docker Compose）
+
+## Goal
+
+FT1〜FT9 はすべて SQLite を使用。MySQL 8 で初めて以下を検証：
+
+1. Docker Compose で MySQL 8 を立ち上げる手順
+2. `SqlAlchemyQueryExecutor` / `SqlAlchemyTransactionManager` の MySQL 上での動作
+3. `parse_db_datetime()` が MySQL の `datetime` オブジェクトを正しく処理するか
+4. SQLite との挙動差（`CURRENT_TIMESTAMP` 型、`RETURNING` 句）
+
+---
+
+## Steps Taken
+
+### 1. Docker Compose で MySQL 8 を起動
+
+```yaml
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: inventory
+      MYSQL_USER: appuser
+      MYSQL_PASSWORD: apppass
+    ports:
+      - "3310:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uappuser", "-papppass"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+```
+
+`depends_on: condition: service_healthy` でアプリが MySQL の起動完了後に起動する構成。
+
+### 2. 接続文字列と依存
+
+```python
+url = f"mysql+pymysql://{user}:{password}@{host}:{port}/{name}"
+engine = create_engine(url, pool_pre_ping=True)
+```
+
+`pymysql` + `cryptography` を追加（MySQL 8 の認証プラグイン `caching_sha2_password` 対応に必要）。
+
+### 3. `CURRENT_TIMESTAMP` の型差異の確認
+
+| DB | `CURRENT_TIMESTAMP` の Python 型 | `parse_db_datetime()` の結果 |
+|----|----------------------------------|------------------------------|
+| SQLite | `str` (`"2026-05-20 12:34:56"`) | ✓ UTC-aware datetime |
+| MySQL | `datetime` (naive, server timezone) | ✓ UTC-aware datetime |
+
+MySQL は `datetime` オブジェクトを返すが naive（tzinfo なし）。
+`parse_db_datetime()` が `isinstance(value, datetime)` で分岐して `.replace(tzinfo=UTC)` を付与するため、
+SQLite と同一の出力が得られることを確認。
+
+### 4. SELECT-after-INSERT の動作確認
+
+`RETURNING` 句は MySQL 8.0 でサポートされていない（PostgreSQL にはある）。
+FT8 で採用した SELECT-after-INSERT パターンがそのまま動作：
+
+```python
+new_id = executor.write("INSERT INTO products ...", {...})
+row = executor.fetch_one("SELECT ... WHERE id = :id", {"id": new_id})
+```
+
+`executor.write()` の戻り値 (`lastrowid`) が MySQL でも正しく返ることを確認。
+
+---
+
+## Friction Points
+
+### FT10-1: `cryptography` が暗黙の依存として必要（ドキュメントなし）
+
+- **摩擦**: `pymysql` を追加しただけでは MySQL 8 の `caching_sha2_password` 認証が失敗する
+  ```
+  OperationalError: Authentication plugin 'caching_sha2_password' is not supported
+  ```
+- `cryptography` パッケージを別途追加する必要があるが、エラーメッセージが分かりにくい
+- **深刻度**: MEDIUM（初見では原因が pymysql の依存問題と気づきにくい）
+- **解決策**: how-to ガイドに `cryptography` を必須依存として明記（ドキュメント対応）
+
+### FT10-2: `PaginationResponse[T].to_dict()` が items を直列化しない
+
+- **摩擦**: `PaginationResponse[ProductOutput].to_dict()` の `items` フィールドが
+  `ProductOutput` dataclass インスタンスのまま返る → `json.dumps` が失敗
+  ```
+  TypeError: Object of type ProductOutput is not JSON serializable
+  ```
+- `slots=True` の dataclass は `__dict__` を持たないため `JSONResponse(result.__dict__)` も使えない
+- **回避策**: ハンドラーで `[dataclasses.asdict(item) for item in result.items]` に変換
+  ```python
+  return JSONResponse({
+      "items": [dataclasses.asdict(item) for item in result.items],
+      "total": result.total,
+      "limit": result.limit,
+      "offset": result.offset,
+  })
+  ```
+- **深刻度**: HIGH（LIST エンドポイントを書くたびに同じ回避策が必要）
+- **解決策候補**: `PaginationResponse.to_dict()` が dataclass items を自動変換する、
+  または `to_json_dict()` メソッドを追加する
+
+### FT10-3: `ValidationError` の `code` 引数がドキュメントに不足
+
+- **摩擦**: `ValidationError("field", "message")` → `TypeError: missing 1 required argument: 'code'`
+- FT1〜FT9 の既存プロジェクトのコードを参考に 2 引数で書くと失敗する
+- **深刻度**: MEDIUM（他のFTのコードがすべて3引数になっていれば問題ない）
+- **解決策**: how-to ガイドのサンプルコードに `code` 引数を必ず含める
+
+### FT10-4: `DatabaseHealthCheck(executor)` vs `DatabaseHealthCheck(engine)` が紛らわしい
+
+- **摩擦**: `DatabaseHealthCheck` のコンストラクタは `executor` を受け取るが、
+  `create_engine()` の直後に書くと `engine` を渡してしまいやすい
+  ```python
+  engine = create_engine(url)
+  executor = SqlAlchemyQueryExecutor(engine)
+  # 間違い: DatabaseHealthCheck(engine)  ← AttributeError: 'Engine' has no 'fetch_one'
+  # 正しい: DatabaseHealthCheck(executor)
+  ```
+- **深刻度**: LOW（エラーメッセージから原因は特定できる）
+- **解決策**: ドキュメントの使用例を正確に記述する
+
+### FT10-5: `PaginationQueryParser` を FastAPI のパラメータ型として使えない
+
+- **摩擦**: `def list_products(pagination: PaginationQueryParser)` と書くと
+  `FastAPIError: Invalid args for response field` が発生
+- `PaginationQueryParser` は Pydantic モデルではないため、FastAPI の Depends として使えない
+- **回避策**: `request: Request` を受け取り `PaginationQueryParser.parse(request)` を呼ぶ
+- **深刻度**: MEDIUM（直感的な書き方が失敗する）
+- **解決策候補**: `PaginationQueryParser` を `Depends` 互換にする、または
+  `Annotated[PaginationQueryParser, Depends(PaginationQueryParser.parse)]` パターンを提供
+
+---
+
+## Summary
+
+| ID      | 摩擦                                                  | 深刻度 | 解決策                                                    |
+|---------|-------------------------------------------------------|--------|-----------------------------------------------------------|
+| FT10-1  | `cryptography` が暗黙依存（MySQL 8 認証失敗）         | MEDIUM | how-to ガイドに記載                                       |
+| FT10-2  | `PaginationResponse.to_dict()` が items を直列化しない | HIGH   | `to_dict()` に dataclass 自動変換を追加                  |
+| FT10-3  | `ValidationError` の `code` 引数がドキュメント不足    | MEDIUM | how-to サンプルコードを修正                               |
+| FT10-4  | `DatabaseHealthCheck(executor)` vs `engine)` が紛らわしい | LOW | ドキュメント修正                                          |
+| FT10-5  | `PaginationQueryParser` が FastAPI パラメータ型不可   | MEDIUM | `Depends` 互換パターンを提供                              |
+
+**MySQL 固有の問題は FT10-1 のみ**。他は SQLite でも同様に起きる問題（FT1〜9 でたまたま発覚しなかった）。
+`parse_db_datetime()` は MySQL の naive datetime を期待通り UTC-aware に変換できた。
+
+FT11 候補:
+- **FT10-2 の修正**: `PaginationResponse.to_dict()` dataclass 自動変換
+- **FT10-5 の修正**: `PaginationQueryParser` を `Depends` 互換に
+- **PostgreSQL アダプター**: `RETURNING` 句が使えるかを検証
+- **`BearerTokenMiddleware` + `HttpxMcpClient`**: 認証付き API を MCP から呼ぶ

--- a/docs/how-to/sqlalchemy-repository.md
+++ b/docs/how-to/sqlalchemy-repository.md
@@ -500,3 +500,81 @@ class InMemoryTransactionManager(DatabaseTransactionManagerInterface):
 ```
 
 > **Rollback on exception**: `SqlAlchemyTransactionManager.transactional()` uses `engine.begin()` — any exception inside the callback triggers an automatic rollback. Domain exceptions (`AccountNotFoundException`, etc.) propagate normally after rollback.
+
+---
+
+## 6. Using MySQL 8
+
+### Required packages
+
+MySQL 8 uses `caching_sha2_password` authentication by default.
+Install **both** `pymysql` and `cryptography` — without `cryptography` the connection fails with
+`Authentication plugin 'caching_sha2_password' is not supported`.
+
+```bash
+uv add pymysql cryptography
+```
+
+### Connection URL
+
+```python
+url = f"mysql+pymysql://{user}:{password}@{host}:{port}/{name}"
+engine = create_engine(url, pool_pre_ping=True)
+```
+
+`pool_pre_ping=True` is recommended for MySQL — it tests the connection before use to handle
+stale connections after the server's `wait_timeout`.
+
+### Health check
+
+`DatabaseHealthCheck` takes a **`SqlAlchemyQueryExecutor`**, not the engine directly:
+
+```python
+from nene2.database import DatabaseHealthCheck, SqlAlchemyQueryExecutor
+
+executor = SqlAlchemyQueryExecutor(engine)
+health = DatabaseHealthCheck(executor)   # ← executor, not engine
+
+app.add_api_route("/health", health.check, methods=["GET"])
+```
+
+### `CURRENT_TIMESTAMP` type difference
+
+SQLite returns `CURRENT_TIMESTAMP` as a `str`; MySQL returns a naive `datetime` object.
+Use `parse_db_datetime()` in `_to_entity()` to handle both transparently:
+
+```python
+from nene2.database import parse_db_datetime
+
+def _to_entity(row: dict[str, Any]) -> Product:
+    return Product(
+        id=int(row["id"]),
+        created_at=parse_db_datetime(row["created_at"]),  # works for both SQLite and MySQL
+    )
+```
+
+### Docker Compose example
+
+```yaml
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: mydb
+      MYSQL_USER: appuser
+      MYSQL_PASSWORD: apppass
+    ports:
+      - "3310:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uappuser", "-papppass"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build: .
+    depends_on:
+      mysql:
+        condition: service_healthy
+```

--- a/docs/reference/framework-modules.md
+++ b/docs/reference/framework-modules.md
@@ -10,6 +10,20 @@ Public API of the `nene2` package.
 
 Parses `limit` and `offset` query parameters.
 
+**FastAPI Depends (recommended)**:
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from nene2.http import PaginationQueryParser
+
+@router.get("/items")
+def list_items(pagination: Annotated[PaginationQueryParser, Depends()]) -> JSONResponse:
+    result = use_case.execute(pagination.limit, pagination.offset)
+```
+
+**Legacy (Request-based)**:
+
 ```python
 from nene2.http import PaginationQueryParser
 

--- a/src/nene2/http/pagination.py
+++ b/src/nene2/http/pagination.py
@@ -3,10 +3,11 @@
 Equivalent to PHP Nene2\\Http\\PaginationQueryParser, PaginationQuery, PaginationResponse.
 """
 
+import dataclasses
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import Request
+from fastapi import Query, Request
 
 from nene2.validation.exceptions import ValidationError, ValidationException
 
@@ -20,7 +21,33 @@ class PaginationQuery:
 
 
 class PaginationQueryParser:
-    """Parses and validates pagination query parameters from a FastAPI Request."""
+    """Parses and validates pagination query parameters.
+
+    Two usage patterns:
+
+    **FastAPI Depends (recommended)**::
+
+        from typing import Annotated
+        from fastapi import Depends
+
+
+        def list_items(pagination: Annotated[PaginationQueryParser, Depends()]) -> JSONResponse:
+            result = use_case.execute(pagination.limit, pagination.offset)
+
+    **Manual parse from Request (legacy)**::
+
+        def list_items(request: Request) -> JSONResponse:
+            pagination = PaginationQueryParser.parse(request)
+            result = use_case.execute(pagination.limit, pagination.offset)
+    """
+
+    def __init__(
+        self,
+        limit: Annotated[int, Query(ge=1, le=100, description="Items per page (1–100)")] = 20,
+        offset: Annotated[int, Query(ge=0, description="Items to skip")] = 0,
+    ) -> None:
+        self.limit = limit
+        self.offset = offset
 
     @staticmethod
     def parse(
@@ -83,8 +110,18 @@ class PaginationResponse:
     total: int | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict.
+
+        Items that are dataclass instances are converted via ``dataclasses.asdict()``
+        so that ``JSONResponse(result.to_dict())`` works without extra steps.
+        """
         data: dict[str, Any] = {
-            "items": self.items,
+            "items": [
+                dataclasses.asdict(item)
+                if dataclasses.is_dataclass(item) and not isinstance(item, type)
+                else item
+                for item in self.items
+            ],
             "limit": self.limit,
             "offset": self.offset,
         }

--- a/tests/nene2/http/test_pagination.py
+++ b/tests/nene2/http/test_pagination.py
@@ -1,9 +1,11 @@
 """Tests for PaginationQueryParser and PaginationResponse."""
 
+from dataclasses import dataclass
+from typing import Annotated
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
@@ -17,6 +19,12 @@ def _make_app() -> FastAPI:
     @app.get("/items")
     async def items(request: Request) -> JSONResponse:
         pagination = PaginationQueryParser.parse(request)
+        return JSONResponse({"limit": pagination.limit, "offset": pagination.offset})
+
+    @app.get("/items-depends")
+    async def items_depends(
+        pagination: Annotated[PaginationQueryParser, Depends()],
+    ) -> JSONResponse:
         return JSONResponse({"limit": pagination.limit, "offset": pagination.offset})
 
     return app
@@ -86,3 +94,34 @@ def test_pagination_response_with_total() -> None:
 def test_pagination_response_total_zero_is_included() -> None:
     r = PaginationResponse(items=[], limit=10, offset=0, total=0)
     assert r.to_dict()["total"] == 0
+
+
+def test_pagination_query_parser_as_depends_default() -> None:
+    r = client.get("/items-depends")
+    assert r.json() == {"limit": 20, "offset": 0}
+
+
+def test_pagination_query_parser_as_depends_custom() -> None:
+    r = client.get("/items-depends?limit=5&offset=10")
+    assert r.json() == {"limit": 5, "offset": 10}
+
+
+def test_pagination_query_parser_as_depends_out_of_range_returns_422() -> None:
+    r = client.get("/items-depends?limit=0")
+    assert r.status_code == 422
+
+
+def test_pagination_response_to_dict_serializes_dataclass_items() -> None:
+    @dataclass(frozen=True, slots=True)
+    class Item:
+        id: int
+        name: str
+
+    r = PaginationResponse(items=[Item(1, "foo"), Item(2, "bar")], limit=20, offset=0, total=2)
+    data = r.to_dict()
+    assert data["items"] == [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]
+
+
+def test_pagination_response_to_dict_passes_through_dict_items() -> None:
+    r = PaginationResponse(items=[{"id": 1}, {"id": 2}], limit=20, offset=0, total=2)
+    assert r.to_dict()["items"] == [{"id": 1}, {"id": 2}]


### PR DESCRIPTION
## Summary

- `PaginationResponse.to_dict()` が dataclass items を `dataclasses.asdict()` で自動変換 — Closes #178
- `PaginationQueryParser` に `__init__` を追加し `Annotated[PaginationQueryParser, Depends()]` で使用可能に — Closes #179
- MySQL 8 接続ガイド追加（`cryptography` 必須依存・`pool_pre_ping`・`DatabaseHealthCheck(executor)` 注意点） — Closes #180

## Changes

### `src/nene2/http/pagination.py`

**FT10-2**: `PaginationResponse.to_dict()` に dataclass 自動変換を追加：
```python
# Before: TypeError — ProductOutput is not JSON serializable
JSONResponse(result.to_dict())

# After: 自動的に dict に変換される
JSONResponse(result.to_dict())  # ← そのまま動く
```

**FT10-5**: `PaginationQueryParser.__init__` を追加：
```python
# 新しい書き方（推奨）
def list_items(pagination: Annotated[PaginationQueryParser, Depends()]) -> JSONResponse:
    result = use_case.execute(pagination.limit, pagination.offset)

# 既存の書き方（後方互換）
pagination = PaginationQueryParser.parse(request)
```

### `docs/how-to/sqlalchemy-repository.md`

**FT10-1/4**: MySQL 8 セクションを追加：
- `pymysql` + `cryptography` の両方が必要な理由を説明
- `DatabaseHealthCheck(executor)` の正しい使い方を明示
- `pool_pre_ping=True` の推奨
- Docker Compose サンプル付き

### `docs/reference/framework-modules.md`

`PaginationQueryParser` の使用例を `Depends()` パターンに更新

## Test plan

- [x] `uv run pytest` — 201 tests passed, 92% coverage
- [x] `uv run mypy src/` — strict clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)