### PR TITLE
ci: GitHub Release のノートを CHANGELOG から自動抽出

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,8 +89,17 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md | sed '/^[[:space:]]*$/d;/^---$/d' | sed '1{/^[[:space:]]*$/d}')
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.notes }}


### PR DESCRIPTION
## Summary

- `generate_release_notes: true`（GitHub の自動生成）を廃止
- `CHANGELOG.md` の該当バージョンセクションを `awk` で抽出し `body` に渡す
- 既存リリース v1.1.0〜v1.4.0 のノートは API 経由で手動更新済み

## Test plan

- [x] CI (pytest + mypy + ruff) — ワークフロー変更のみ
- [x] `gh release view v1.4.0` で CHANGELOG の内容が正しく反映されていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)