### PR TITLE
ci: ドメイン・UseCase 層の 90% カバレッジゲートを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: pytest (with coverage)
         run: uv run pytest
 
+      - name: coverage gate — domain/use_case layers (90%)
+        run: |
+          uv run coverage report \
+            --include="src/example/*/use_case.py,src/example/*/async_use_case.py,src/example/*/entity.py" \
+            --fail-under=90
+
       - name: mypy
         run: uv run mypy src/
 


### PR DESCRIPTION
## Summary

CLAUDE.md に「ドメイン・UseCase 層は 90% 以上を目標」と明記されているが、CI で強制されていなかった。全体 80% ゲートだけだとドメイン層が薄くなっても通り抜けられるため、独立したステップを追加。

対象: `src/example/*/use_case.py`, `async_use_case.py`, `entity.py`
閾値: 90%（現状 100%）

## Test plan

- [x] ローカルで `coverage report --include="..." --fail-under=90` が通ることを確認（全対象 100%）
- [x] CI green 待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)