### PR TITLE
feat: ThrottleMiddleware・RequestSizeLimitMiddleware に exclude_paths を追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-12.md
+++ b/docs/field-trials/2026-05-field-trial-12.md
@@ -1,0 +1,58 @@
+# Field Trial 12 — ThrottleMiddleware + RequestSizeLimitMiddleware 実運用
+
+**Date:** 2026-05-20
+**App:** Chirp API（短文投稿 API、レート制限 + ペイロード制限付き）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft12-throttle/`
+**nene2-python version:** v1.4.0
+
+## 概要
+
+`ThrottleMiddleware`（固定ウィンドウレート制限）と `RequestSizeLimitMiddleware`（リクエストボディ制限）を実際のアプリに組み込み、動作と摩擦点を確認した。
+
+## 動作確認結果
+
+- `ThrottleMiddleware(limit=3, window=60)` で3リクエスト後に 429 + `Retry-After` ヘッダーが返ること ✓
+- `RequestSizeLimitMiddleware(max_bytes=100)` でペイロード超過時に 413 が返ること ✓
+- 両ミドルウェアとも Problem Details (RFC 9457) 形式でエラーレスポンスが返ること ✓
+- `AppSettings` に `throttle_limit`, `throttle_window`, `max_body_size` が揃っていること ✓
+
+## 摩擦点
+
+### FT12-F1 (MEDIUM): ThrottleMiddleware に exclude_paths がない
+
+BearerTokenMiddleware・ApiKeyAuthMiddleware は FT11 で `exclude_paths` を追加したが、
+`ThrottleMiddleware` には同パラメータがない。
+
+```python
+# やりたいこと: /health はレート制限の対象外にしたい
+app.add_middleware(
+    ThrottleMiddleware,
+    limit=60,
+    window=60,
+    exclude_paths=["/health", "/docs"],  # ← 存在しない
+)
+```
+
+実際には `/health` も 60req/min のレート制限にかかる。ロードバランサーのヘルスチェックが
+高頻度で叩く環境では 429 が返り、インスタンスがダウン扱いになるリスクがある。
+
+**再現コード:**
+```python
+app.add_middleware(ThrottleMiddleware, limit=2, window=60)
+# /health を3回叩くと3回目が 429
+```
+
+### FT12-F2 (MEDIUM): RequestSizeLimitMiddleware に exclude_paths がない
+
+同様に `RequestSizeLimitMiddleware` にも `exclude_paths` がない。
+実用上の影響は ThrottleMiddleware より小さいが（GET リクエストはボディなしなので通常問題ない）、
+一貫性の観点から揃えるべき。
+
+BearerTokenMiddleware, ApiKeyAuthMiddleware, ThrottleMiddleware がすべて `exclude_paths` を
+持つのに RequestSizeLimitMiddleware だけ持たない状態は混乱を招く。
+
+## まとめ
+
+基本動作は問題なし。FT11 で auth 系ミドルウェアに `exclude_paths` を追加したが、
+同じ修正が `ThrottleMiddleware` と `RequestSizeLimitMiddleware` にも必要。
+3つのミドルウェアで `exclude_paths` の有無が揃っていないことが主な摩擦。

--- a/src/nene2/middleware/request_size_limit.py
+++ b/src/nene2/middleware/request_size_limit.py
@@ -22,13 +22,31 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
     Checks the Content-Length header first for a fast pre-flight reject,
     then reads the actual body to catch chunked-transfer requests that
     omit Content-Length entirely.
+
+    Use ``exclude_paths`` to bypass the size limit for specific endpoints::
+
+        app.add_middleware(
+            RequestSizeLimitMiddleware,
+            max_bytes=1_048_576,
+            exclude_paths=["/upload/multipart"],
+        )
     """
 
-    def __init__(self, app: object, *, max_bytes: int = _DEFAULT_MAX_BYTES) -> None:
+    def __init__(
+        self,
+        app: object,
+        *,
+        max_bytes: int = _DEFAULT_MAX_BYTES,
+        exclude_paths: list[str] | None = None,
+    ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._max_bytes = max_bytes
+        self._exclude_paths = set(exclude_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self._exclude_paths:
+            return await call_next(request)
+
         content_length = request.headers.get("Content-Length")
         if content_length is not None:
             try:

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -25,7 +25,17 @@ _DEFAULT_WINDOW = 60  # seconds
 
 
 class ThrottleMiddleware(BaseHTTPMiddleware):
-    """Fixed-window rate limiter keyed by client IP."""
+    """Fixed-window rate limiter keyed by client IP.
+
+    Use ``exclude_paths`` to bypass rate limiting for health checks and API docs::
+
+        app.add_middleware(
+            ThrottleMiddleware,
+            limit=60,
+            window=60,
+            exclude_paths=["/health", "/docs", "/openapi.json"],
+        )
+    """
 
     def __init__(
         self,
@@ -33,10 +43,12 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         *,
         limit: int = _DEFAULT_LIMIT,
         window: int = _DEFAULT_WINDOW,
+        exclude_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._limit = limit
         self._window = window
+        self._exclude_paths = set(exclude_paths or [])
         self._counts: dict[str, tuple[int, float]] = {}
         self._lock = threading.Lock()
 
@@ -58,6 +70,8 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         return count <= self._limit, remaining
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self._exclude_paths:
+            return await call_next(request)
         key = self._client_key(request)
         allowed, retry_after = self._is_allowed(key)
         if not allowed:

--- a/tests/nene2/middleware/test_request_size_limit.py
+++ b/tests/nene2/middleware/test_request_size_limit.py
@@ -66,3 +66,24 @@ def test_malformed_content_length_is_tolerated() -> None:
         headers={"Content-Length": "abc", "Content-Type": "application/octet-stream"},
     )
     assert response.status_code == 200
+
+
+def test_exclude_paths_bypasses_size_limit() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        RequestSizeLimitMiddleware,
+        max_bytes=10,
+        exclude_paths=["/upload/large"],
+    )
+
+    @app.post("/upload")
+    async def upload() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.post("/upload/large")
+    async def upload_large() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.post("/upload", content=b"x" * 100).status_code == 413
+    assert client.post("/upload/large", content=b"x" * 100).status_code == 200

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -43,3 +43,35 @@ def test_forwarded_for_header_used_as_key() -> None:
 
     response2 = client.get("/ping", headers={"X-Forwarded-For": "10.0.0.2"})
     assert response2.status_code == 200
+
+
+def test_exclude_paths_bypasses_throttle() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ThrottleMiddleware,
+        limit=2,
+        window=60,
+        exclude_paths=["/health"],
+    )
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    for _ in range(5):
+        assert client.get("/health").status_code == 200
+
+    client.get("/ping")
+    client.get("/ping")
+    assert client.get("/ping").status_code == 429
+
+
+def test_exclude_paths_default_is_empty() -> None:
+    client = TestClient(_make_app(limit=1))
+    client.get("/ping")
+    assert client.get("/ping").status_code == 429


### PR DESCRIPTION
## Summary

FT12 (ThrottleMiddleware実運用) で発見した摩擦点の修正。

- **#195** `ThrottleMiddleware` に `exclude_paths` 追加（ヘルスチェックがレート制限される問題）
- **#196** `RequestSizeLimitMiddleware` に `exclude_paths` 追加（auth系ミドルウェアとの一貫性）

全ミドルウェアで `exclude_paths` パターンが統一された。

## Test plan

- [x] `test_exclude_paths_bypasses_throttle` — limit=2 でも除外パスは無制限に通る
- [x] `test_exclude_paths_default_is_empty` — デフォルトは全パス対象
- [x] `test_exclude_paths_bypasses_size_limit` — 除外パスはサイズ制限をスキップ
- [x] 210 tests passed, coverage 92.52%, mypy strict clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)