### PR TITLE
feat: ValidationException.single() と ValidationError エラーメッセージ改善

### DIFF
--- a/docs/field-trials/2026-05-field-trial-13.md
+++ b/docs/field-trials/2026-05-field-trial-13.md
@@ -1,0 +1,54 @@
+# Field Trial 13 — ValidationException 実運用
+
+**Date:** 2026-05-20
+**App:** User Registration API（メール・パスワード・年齢の複合バリデーション）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft13-validation/`
+**nene2-python version:** v1.5.0
+
+## 概要
+
+`ValidationException` と `ValidationError` を実際のアプリで使い、
+複数フィールドのバリデーション・複数エラーの集約・レスポンス形式を検証した。
+
+## 動作確認結果
+
+- 複数フィールドのバリデーションエラーが一度に返ること ✓（fail-fast ではなく fail-all）
+- `ErrorHandlerMiddleware` が `ValidationException` を 422 に変換すること ✓
+- レスポンスが RFC 9457 形式で `errors` 配列を含むこと ✓
+- `ValidationError` の `field`, `message`, `code` が全フィールドで返ること ✓
+
+## 摩擦点
+
+### FT13-F1 (LOW): 単一エラーでもリストラップが必要
+
+単一フィールドのエラーでも `list` でラップする必要があり、やや冗長。
+
+```python
+# 現状（毎回リストが必要）
+raise ValidationException([ValidationError("email", "invalid", "invalid_email")])
+
+# こうしたい
+raise ValidationException.single("email", "invalid", "invalid_email")
+```
+
+特に UseCase 層で早期リターンするケース（1つのエラーが致命的で後続チェック不要な場合）に
+`ValidationException([...])` は読みにくい。
+
+### FT13-F2 (LOW): ValidationError の空文字エラーメッセージがどのフィールドか不明
+
+`ValidationError("", "message", "code")` を作ると `ValueError: field, message, and code must be non-empty strings` が出るが、どのフィールドが空かわからない。開発時のデバッグに時間がかかる。
+
+```python
+# 現状
+ValidationError("", "msg", "code")
+# → ValueError: field, message, and code must be non-empty strings
+
+# 改善案
+# → ValueError: ValidationError.field must not be empty
+```
+
+## まとめ
+
+`ValidationException` の基本動作は問題なし。摩擦は軽微で、実務で使うのに大きな障壁はない。
+FT13-F1 の `ValidationException.single()` はよくある単一エラーケースの DX 改善として有用。
+FT13-F2 はデバッグ時の QoL 向上。どちらも LOW 優先度。

--- a/src/nene2/validation/exceptions.py
+++ b/src/nene2/validation/exceptions.py
@@ -16,8 +16,9 @@ class ValidationError:
     code: str
 
     def __post_init__(self) -> None:
-        if not self.field or not self.message or not self.code:
-            raise ValueError("field, message, and code must be non-empty strings")
+        for attr in ("field", "message", "code"):
+            if not getattr(self, attr):
+                raise ValueError(f"ValidationError.{attr} must not be empty")
 
     def to_dict(self) -> dict[str, str]:
         return {"field": self.field, "message": self.message, "code": self.code}
@@ -27,8 +28,25 @@ class ValidationException(Exception):
     """Raised when one or more validation rules fail.
 
     ErrorHandlerMiddleware maps this to a 422 validation-failed Problem Details response.
+
+    For a single error, use the convenience method::
+
+        raise ValidationException.single("email", "invalid", "invalid_email")
+
+    For multiple errors accumulated during validation::
+
+        errors = []
+        if not valid_email:
+            errors.append(ValidationError("email", "invalid", "invalid_email"))
+        if errors:
+            raise ValidationException(errors)
     """
 
     def __init__(self, errors: list[ValidationError]) -> None:
         super().__init__("Validation failed")
         self.errors = errors
+
+    @classmethod
+    def single(cls, field: str, message: str, code: str) -> "ValidationException":
+        """Convenience constructor for a single validation error."""
+        return cls([ValidationError(field, message, code)])

--- a/tests/nene2/validation/test_exceptions.py
+++ b/tests/nene2/validation/test_exceptions.py
@@ -20,3 +20,27 @@ def test_validation_exception_stores_errors() -> None:
     exc = ValidationException(errors)
     assert exc.errors == errors
     assert str(exc) == "Validation failed"
+
+
+def test_validation_error_empty_field_message_names_the_field() -> None:
+    with pytest.raises(ValueError, match="ValidationError.field must not be empty"):
+        ValidationError(field="", message="msg", code="code")
+
+    with pytest.raises(ValueError, match="ValidationError.message must not be empty"):
+        ValidationError(field="f", message="", code="code")
+
+    with pytest.raises(ValueError, match="ValidationError.code must not be empty"):
+        ValidationError(field="f", message="msg", code="")
+
+
+def test_validation_exception_single() -> None:
+    exc = ValidationException.single("email", "invalid", "invalid_email")
+    assert len(exc.errors) == 1
+    assert exc.errors[0].field == "email"
+    assert exc.errors[0].message == "invalid"
+    assert exc.errors[0].code == "invalid_email"
+
+
+def test_validation_exception_single_is_validation_exception() -> None:
+    exc = ValidationException.single("f", "m", "c")
+    assert isinstance(exc, ValidationException)


### PR DESCRIPTION
## Summary

FT13 (ValidationException実運用) で発見した摩擦点の修正。

- **#200** `ValidationException.single(field, message, code)` クラスメソッドを追加（単一エラー raise の冗長性解消）
- **#201** `ValidationError.__post_init__` のエラーメッセージを改善（どのフィールドが空かを明示）

## Test plan

- [x] `test_validation_exception_single` — single() が正しく1エラーの ValidationException を返す
- [x] `test_validation_error_empty_field_message_names_the_field` — field/message/code それぞれの空文字エラーが正しく識別される
- [x] 213 tests passed, coverage 92.55%, mypy strict clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)