### PR TITLE
docs: AsyncUseCaseProtocol/UseCaseProtocol docstring に runtime_checkable の制限を明記

### DIFF
--- a/docs/field-trials/2026-05-field-trial-14.md
+++ b/docs/field-trials/2026-05-field-trial-14.md
@@ -1,0 +1,45 @@
+# Field Trial 14 — AsyncUseCaseProtocol 実運用
+
+**Date:** 2026-05-20
+**App:** Weather Dashboard API（複数都市の天気を asyncio.gather で並列取得）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft14-async/`
+**nene2-python version:** v1.6.0
+
+## 概要
+
+`AsyncUseCaseProtocol` を使った非同期 UseCase を実際に実装し、
+`asyncio.gather` による並列 I/O の動作とプロトコルの挙動を検証した。
+
+## 動作確認結果
+
+- `AsyncUseCaseProtocol` の `isinstance` 検査が正しく動くこと ✓
+- `asyncio.gather` で 4 都市を並列取得した場合、50ms（直列の場合 200ms）で完了すること ✓
+- `FetchDashboardUseCase(fetch_weather: AsyncUseCaseProtocol[...])` のコンストラクタインジェクションが機能すること ✓
+- FastAPI の `async def` ハンドラーから非同期 UseCase を `await` で呼び出せること ✓
+
+## 摩擦点
+
+### FT14-F1 (LOW, ドキュメント): runtime_checkable の制限がプロトコルの docstring に記載されていない
+
+`isinstance(sync_obj, AsyncUseCaseProtocol)` が `True` を返す（Python の `@runtime_checkable` は
+メソッド名の存在のみを検査し、async/sync を区別しない）。
+
+```python
+class FakeSyncWeather:
+    def execute(self, input_: WeatherInput) -> str:  # async ではない
+        return "fake"
+
+isinstance(FakeSyncWeather(), AsyncUseCaseProtocol)  # → True（注意が必要）
+```
+
+この制限は ADR-0010 に記録済みだが、`AsyncUseCaseProtocol` の docstring には記載されていない。
+利用者が docstring だけ見て `isinstance` でランタイムガードを書くと誤動作する。
+
+**対応**: プロトコルの docstring に「mypy --strict が静的に保証する; isinstance はメソッド名のみを検査する」旨を追記する。
+
+## まとめ
+
+基本動作は問題なし。`asyncio.gather` パターン・コンストラクタインジェクション・FastAPI 統合のいずれも
+摩擦なく動作した。唯一の摩擦は docstring によるドキュメントギャップ（LOW）のみ。
+
+FT14 は「設計が正しく実装されている」ことの確認として有用だった。

--- a/src/nene2/use_case/protocols.py
+++ b/src/nene2/use_case/protocols.py
@@ -5,6 +5,23 @@ AsyncUseCaseProtocol — async execute(input_) -> output (awaitable)
 
 Both use Python 3.12 generic syntax; any class with a matching
 execute() signature satisfies them structurally (no inheritance needed).
+
+Runtime isinstance() limitation
+---------------------------------
+Both protocols are @runtime_checkable, but Python's isinstance() only
+checks that the ``execute`` attribute exists — it does NOT distinguish
+between sync and async implementations. As a result:
+
+    isinstance(sync_obj, AsyncUseCaseProtocol)  # → True (false positive)
+    isinstance(async_obj, UseCaseProtocol)       # → True (false positive)
+
+Static type safety (sync vs async) is guaranteed by mypy --strict, not
+by isinstance() at runtime. If you need a runtime async check, use:
+
+    import inspect
+    inspect.iscoroutinefunction(obj.execute)
+
+See ADR-0010 for the full rationale.
 """
 
 from typing import Protocol, runtime_checkable
@@ -12,13 +29,23 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class UseCaseProtocol[I, O](Protocol):
-    """Synchronous use-case contract."""
+    """Synchronous use-case contract.
+
+    Warning: isinstance() only checks that ``execute`` exists, not whether
+    it is synchronous. Use mypy --strict for compile-time enforcement, or
+    ``not inspect.iscoroutinefunction(obj.execute)`` for a runtime check.
+    """
 
     def execute(self, input_: I) -> O: ...
 
 
 @runtime_checkable
 class AsyncUseCaseProtocol[I, O](Protocol):
-    """Asynchronous use-case contract — execute must be a coroutine."""
+    """Asynchronous use-case contract — execute must be a coroutine.
+
+    Warning: isinstance() only checks that ``execute`` exists, not whether
+    it is async. Use mypy --strict for compile-time enforcement, or
+    ``inspect.iscoroutinefunction(obj.execute)`` for a runtime check.
+    """
 
     async def execute(self, input_: I) -> O: ...


### PR DESCRIPTION
## Summary

- FT14 (AsyncUseCaseProtocol実運用) で発見した FT14-F1 (LOW) への対応
- `AsyncUseCaseProtocol` と `UseCaseProtocol` の docstring に `@runtime_checkable` の制限を明記
- `isinstance()` はメソッド名の存在のみを検査し、async/sync を区別しないことを説明
- ランタイムで async を確認する場合は `inspect.iscoroutinefunction(obj.execute)` を使うよう案内
- FT14 フィールドトライアルレポートを `docs/field-trials/2026-05-field-trial-14.md` に追加

Closes #205

## Test plan
- [ ] `uv run pytest` — 213 tests pass
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check` — no issues
- [ ] `uv run ruff format --check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)