### PR TITLE
feat: SecurityHeadersMiddleware に csp/extra_no_csp_paths パラメータを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-15.md
+++ b/docs/field-trials/2026-05-field-trial-15.md
@@ -1,0 +1,67 @@
+# Field Trial 15 — SecurityHeadersMiddleware 実運用
+
+**Date:** 2026-05-20
+**App:** FT15 Security Headers API（セキュリティヘッダーの付与・CSP 動作確認）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft15-security-headers/`
+**nene2-python version:** v1.6.0
+
+## 概要
+
+`SecurityHeadersMiddleware` を実際のアプリに組み込み、各ヘッダーの付与動作・
+CSP スキップロジック・カスタマイズ可能性を検証した。
+
+## 動作確認結果
+
+- 通常エンドポイントに `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy`, `Permissions-Policy` の全ヘッダーが付与されること ✓
+- `/docs`, `/redoc`, `/openapi.json` では `Content-Security-Policy` がスキップされること ✓
+- CSP スキップ時も他のヘッダーは引き続き付与されること ✓
+
+## 摩擦点
+
+### FT15-F1 (MEDIUM, 拡張性): カスタム OpenAPI パスで CSP スキップが効かない
+
+`SecurityHeadersMiddleware` がスキップする OpenAPI パスは `_OPENAPI_PATHS` 定数で
+`{"/docs", "/redoc", "/openapi.json"}` にハードコードされている。
+
+FastAPI では `docs_url` / `redoc_url` でカスタムパスを設定できるが、
+カスタムパス（例: `/api-docs`）では CSP スキップが効かず、Swagger UI が CDN アセットを
+ブロックされる可能性がある。
+
+```python
+app = FastAPI(docs_url="/api-docs", redoc_url="/api-redoc")
+app.add_middleware(SecurityHeadersMiddleware)
+# → /api-docs に CSP "default-src 'self'" が付いてしまう
+```
+
+**対応**: コンストラクタに `extra_no_csp_paths: list[str] | None = None` を追加し、
+ユーザーがカスタム OpenAPI パスを指定できるようにする。または `ThrottleMiddleware` と
+同様の `exclude_paths` パターンで完全スキップを可能にする。
+
+### FT15-F2 (LOW, 拡張性): CSP をコンストラクタで上書きできない
+
+CSP の値 `"default-src 'self'"` はモジュールレベルの `_HEADERS` 定数にハードコードされており、
+コンストラクタから上書きできない。
+
+CDN アセットを許可したい（`content-src 'self' cdn.example.com`）など、
+CSP を変更したいユーザーは `_HEADERS` をモジュールレベルで直接書き換えるしかなく、
+グローバルな副作用が発生する。
+
+```python
+# 現状の唯一の方法（副作用あり）
+from nene2.middleware import security_headers
+security_headers._HEADERS["Content-Security-Policy"] = "default-src 'self' cdn.example.com"
+```
+
+**対応**: `SecurityHeadersMiddleware(csp: str | None = None)` でコンストラクタから
+CSP 値を上書きできるようにする。
+
+## まとめ
+
+基本動作は問題なし。全セキュリティヘッダーの付与・OpenAPI パスでの CSP スキップも
+正常に機能した。摩擦は拡張性の面で2点あり：
+
+- FT15-F1 (MEDIUM): カスタム OpenAPI パスで CSP スキップが効かない
+- FT15-F2 (LOW): CSP 値をコンストラクタから変更できない
+
+`ThrottleMiddleware` が `exclude_paths` を持つのに対し、`SecurityHeadersMiddleware` は
+カスタマイズポイントがゼロであるため、実用アプリでの柔軟性が低い。

--- a/src/nene2/middleware/security_headers.py
+++ b/src/nene2/middleware/security_headers.py
@@ -9,15 +9,16 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 
-_HEADERS: dict[str, str] = {
+_DEFAULT_CSP = "default-src 'self'"
+
+_NON_CSP_HEADERS: dict[str, str] = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Content-Security-Policy": "default-src 'self'",
     "Permissions-Policy": "geolocation=(), microphone=()",
 }
 
-_OPENAPI_PATHS: frozenset[str] = frozenset({"/docs", "/redoc", "/openapi.json"})
+_DEFAULT_NO_CSP_PATHS: frozenset[str] = frozenset({"/docs", "/redoc", "/openapi.json"})
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -25,13 +26,29 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
     Content-Security-Policy is omitted for OpenAPI documentation paths so that
     Swagger UI and ReDoc (which load assets from CDN) continue to work in development.
+
+    Args:
+        csp: Custom Content-Security-Policy header value.
+            Defaults to ``"default-src 'self'"`` when not specified.
+        extra_no_csp_paths: Additional paths to skip the CSP header for.
+            Useful when FastAPI is configured with custom ``docs_url`` / ``redoc_url``.
+            The built-in paths ``/docs``, ``/redoc``, and ``/openapi.json`` are always included.
     """
+
+    def __init__(
+        self,
+        app: object,
+        csp: str | None = None,
+        extra_no_csp_paths: list[str] | None = None,
+    ) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._csp = csp if csp is not None else _DEFAULT_CSP
+        self._no_csp_paths = _DEFAULT_NO_CSP_PATHS | frozenset(extra_no_csp_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
-        is_openapi_path = request.url.path in _OPENAPI_PATHS
-        for header, value in _HEADERS.items():
-            if is_openapi_path and header == "Content-Security-Policy":
-                continue
+        for header, value in _NON_CSP_HEADERS.items():
             response.headers[header] = value
+        if request.url.path not in self._no_csp_paths:
+            response.headers["Content-Security-Policy"] = self._csp
         return response

--- a/tests/nene2/middleware/test_security_headers.py
+++ b/tests/nene2/middleware/test_security_headers.py
@@ -51,3 +51,44 @@ def test_security_headers_on_error_response() -> None:
     response = client.get("/boom")
     assert response.status_code == 404
     assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_custom_csp_value() -> None:
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware, csp="default-src 'self' cdn.example.com")
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    response = client.get("/ping")
+    assert response.headers["Content-Security-Policy"] == "default-src 'self' cdn.example.com"
+
+
+def test_extra_no_csp_paths() -> None:
+    app = FastAPI(docs_url="/api-docs", redoc_url="/api-redoc")
+    app.add_middleware(SecurityHeadersMiddleware, extra_no_csp_paths=["/api-docs", "/api-redoc"])
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert "Content-Security-Policy" not in client.get("/api-docs").headers
+    assert "Content-Security-Policy" not in client.get("/api-redoc").headers
+    assert "Content-Security-Policy" in client.get("/ping").headers
+
+
+def test_default_no_csp_paths_still_work_with_extra_paths() -> None:
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware, extra_no_csp_paths=["/custom"])
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert "Content-Security-Policy" not in client.get("/docs").headers
+    assert "Content-Security-Policy" not in client.get("/custom").headers
+    assert "Content-Security-Policy" in client.get("/ping").headers


### PR DESCRIPTION
## Summary

FT15 (SecurityHeadersMiddleware 実運用) で発見した2つの摩擦点への対応:

- **FT15-F1 (#207)**: カスタム OpenAPI パスで CSP スキップが効かない問題
  - `extra_no_csp_paths: list[str] | None = None` をコンストラクタに追加
  - `FastAPI(docs_url="/api-docs")` などカスタムパスも CSP スキップ対象に指定可能
  - デフォルトの `/docs`, `/redoc`, `/openapi.json` は常に含まれる
- **FT15-F2 (#208)**: CSP 値をコンストラクタから変更できない問題
  - `csp: str | None = None` をコンストラクタに追加
  - `None` の場合はデフォルト `"default-src 'self'"` を使用
  - CDN アセット許可など CSP のカスタマイズが可能に
- FT15 フィールドトライアルレポートを `docs/field-trials/2026-05-field-trial-15.md` に追加

Closes #207, #208

## Test plan
- [ ] `uv run pytest` — 216 tests pass
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check` — no issues
- [ ] `uv run ruff format --check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)