### PR TITLE
feat: DatabaseIntegrityException を追加し IntegrityError をフレームワーク例外に統一

### DIFF
--- a/docs/field-trials/2026-05-field-trial-16.md
+++ b/docs/field-trials/2026-05-field-trial-16.md
@@ -1,0 +1,62 @@
+# Field Trial 16 — transactional(callback) パターン実運用
+
+**Date:** 2026-05-20
+**App:** 銀行口座送金 API（送金元の残高を減らして送金先に加算する atomic 操作）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft16-transaction/`
+**nene2-python version:** v1.6.0
+
+## 概要
+
+`transactional(callback)` パターンを実際の送金ユースケースに適用し、
+ロールバック挙動・例外処理・async コンテキストとの相互作用を検証した。
+
+## 動作確認結果
+
+- `transactional(callback)` が atomic に実行されること ✓
+- `CHECK 制約違反`（残高 < 0）発生時に全操作がロールバックされること ✓
+- `UNIQUE 制約違反`（IntegrityError）でもロールバックが正しく行われること ✓
+- SQLite `:memory:` + `StaticPool` で `SqlAlchemyQueryExecutor` と `SqlAlchemyTransactionManager` を同一 DB に向けられること ✓
+
+## 摩擦点
+
+### FT16-F1 (MEDIUM, API一貫性): IntegrityError が DatabaseConnectionException にラップされない
+
+`SqlAlchemyTransactionManager.transactional()` は `OperationalError` のみを
+`DatabaseConnectionException` に変換し、`IntegrityError`（UNIQUE 制約違反・FK 制約違反など）は
+生の SQLAlchemy 例外として呼び出し側に伝播する。
+
+UseCase 層でフレームワーク独自例外に統一されていないため、
+呼び出し元が SQLAlchemy の例外型に依存した `except IntegrityError` を書く必要がある。
+
+```python
+from sqlalchemy.exc import IntegrityError
+
+with pytest.raises(IntegrityError):  # 摩擦: SQLAlchemy 依存が漏れ出す
+    tx_manager.transactional(_duplicate_insert)
+```
+
+**対応案**: `IntegrityError` も `DatabaseConnectionException`（または新設の `DatabaseIntegrityException`）にラップする。または `transactional()` がキャッチすべき SQLAlchemy 例外一覧をドキュメントに明記する。
+
+### FT16-F2 (LOW, 非同期対応): async コンテキストから transactional() を呼ぶとイベントループをブロックする
+
+`SqlAlchemyTransactionManager.transactional()` は同期 API であるため、
+FastAPI の `async def` ハンドラーから直接呼ぶとイベントループをブロックする。
+現状の実装でも動作はするが、高負荷時にパフォーマンス劣化の原因になりうる。
+
+```python
+@app.post("/transfer")
+async def transfer(...) -> JSONResponse:
+    # 同期 transactional() を直接呼んでいる（イベントループブロッキング）
+    result = transfer_uc.execute(...)
+```
+
+**対応案**: `asyncio.to_thread()` でのラップをドキュメントに記載する。
+または `AsyncSqlAlchemyTransactionManager` を将来的に追加する（SQLAlchemy async core を利用）。
+
+## まとめ
+
+コアの atomic 保証（コミット・ロールバック）は期待通りに機能した。
+摩擦は例外ハンドリングの API 一貫性（F1: MEDIUM）と非同期対応（F2: LOW）の2点。
+
+F1 は UseCase 層が SQLAlchemy に依存するアーキテクチャ上の問題であり、
+Clean Architecture の原則に照らして対応が必要。

--- a/src/nene2/database/__init__.py
+++ b/src/nene2/database/__init__.py
@@ -1,6 +1,6 @@
 """NENE2 database abstraction layer."""
 
-from .exceptions import DatabaseConnectionException
+from .exceptions import DatabaseConnectionException, DatabaseIntegrityException
 from .health import DatabaseHealthCheck
 from .interfaces import DatabaseQueryExecutorInterface, DatabaseTransactionManagerInterface
 from .sqlalchemy_executor import SqlAlchemyQueryExecutor, SqlAlchemyTransactionManager
@@ -8,6 +8,7 @@ from .utils import parse_db_datetime
 
 __all__ = [
     "DatabaseConnectionException",
+    "DatabaseIntegrityException",
     "DatabaseHealthCheck",
     "DatabaseQueryExecutorInterface",
     "DatabaseTransactionManagerInterface",

--- a/src/nene2/database/exceptions.py
+++ b/src/nene2/database/exceptions.py
@@ -3,3 +3,7 @@
 
 class DatabaseConnectionException(Exception):
     """Raised when a database connection cannot be established."""
+
+
+class DatabaseIntegrityException(Exception):
+    """Raised when a database integrity constraint is violated (UNIQUE, FK, CHECK, etc.)."""

--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import Connection, Engine, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 
-from .exceptions import DatabaseConnectionException
+from .exceptions import DatabaseConnectionException, DatabaseIntegrityException
 from .interfaces import DatabaseQueryExecutorInterface, DatabaseTransactionManagerInterface
 
 
@@ -82,6 +82,8 @@ class _BoundQueryExecutor(DatabaseQueryExecutorInterface):
     def write(self, sql: str, params: dict[str, Any] | None = None) -> int:
         try:
             result = self._conn.execute(text(sql), params or {})
+        except IntegrityError as exc:
+            raise DatabaseIntegrityException(str(exc)) from exc
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
         return result.lastrowid or result.rowcount
@@ -104,6 +106,10 @@ class SqlAlchemyTransactionManager(DatabaseTransactionManagerInterface):
         try:
             with self._engine.begin() as conn:
                 return callback(_BoundQueryExecutor(conn))
+        except DatabaseIntegrityException:
+            raise
+        except IntegrityError as exc:
+            raise DatabaseIntegrityException(str(exc)) from exc
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
 

--- a/tests/nene2/database/test_transaction.py
+++ b/tests/nene2/database/test_transaction.py
@@ -4,7 +4,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
-from nene2.database import DatabaseQueryExecutorInterface, SqlAlchemyTransactionManager
+from nene2.database import (
+    DatabaseIntegrityException,
+    DatabaseQueryExecutorInterface,
+    SqlAlchemyTransactionManager,
+)
 
 
 def _manager() -> SqlAlchemyTransactionManager:
@@ -16,7 +20,7 @@ def _manager() -> SqlAlchemyTransactionManager:
     manager = SqlAlchemyTransactionManager(engine)
     manager.transactional(
         lambda ex: ex.write(
-            "CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)"
+            "CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE)"
         )
     )
     return manager
@@ -71,3 +75,28 @@ def test_begin_rollback_workflow() -> None:
     mgr.rollback()
     rows = mgr.transactional(lambda ex: ex.fetch_all("SELECT * FROM items"))
     assert rows == []
+
+
+def test_transactional_raises_database_integrity_exception_on_unique_violation() -> None:
+    mgr = _manager()
+    mgr.transactional(lambda ex: ex.write("INSERT INTO items (name) VALUES ('dup')"))
+
+    def _duplicate(ex: DatabaseQueryExecutorInterface) -> None:
+        ex.write("INSERT INTO items (name) VALUES ('dup')")
+
+    with pytest.raises(DatabaseIntegrityException):
+        mgr.transactional(_duplicate)
+
+
+def test_transactional_rollback_on_integrity_error() -> None:
+    mgr = _manager()
+
+    def _partial_then_fail(ex: DatabaseQueryExecutorInterface) -> None:
+        ex.write("INSERT INTO items (name) VALUES ('first')")
+        ex.write("INSERT INTO items (name) VALUES ('first')")  # UNIQUE violation
+
+    with pytest.raises(DatabaseIntegrityException):
+        mgr.transactional(_partial_then_fail)
+
+    rows = mgr.transactional(lambda ex: ex.fetch_all("SELECT * FROM items"))
+    assert rows == []  # ロールバックされて何も残っていない


### PR DESCRIPTION
## Summary

FT16 (transactional パターン実運用) で発見した FT16-F1 への対応:

- `DatabaseIntegrityException` を新設（`nene2.database.exceptions`）
- `SqlAlchemyTransactionManager.transactional()` で `IntegrityError` をキャッチして `DatabaseIntegrityException` にラップ
- `_BoundQueryExecutor.write()` でも同様に `IntegrityError` を変換
- UseCase 層が `from sqlalchemy.exc import IntegrityError` に依存しなくて済む
- `DatabaseIntegrityException` を `nene2.database` の `__all__` にエクスポート
- FT16 フィールドトライアルレポートを `docs/field-trials/2026-05-field-trial-16.md` に追加

Closes #210

## Test plan
- [ ] `uv run pytest` — 218 tests pass
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check` — no issues
- [ ] `uv run ruff format --check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)