### PR TITLE
fix: SqlAlchemyQueryExecutor.write() の IntegrityError ラップ漏れと UPDATE 戻り値バグを修正

### DIFF
--- a/docs/field-trials/2026-05-field-trial-17.md
+++ b/docs/field-trials/2026-05-field-trial-17.md
@@ -1,0 +1,66 @@
+# Field Trial 17 — 複数ドメイン連携実運用
+
+**Date:** 2026-05-20
+**App:** タスク管理API（Task + Category の2ドメイン連携）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft17-multi-domain/`
+**nene2-python version:** v1.6.0 (local dev build)
+
+## 概要
+
+Task（タスク）と Category（カテゴリ）の2ドメインを連携させたアプリを実装し、
+`SqlAlchemyQueryExecutor.write()` と `DatabaseIntegrityException`、
+`transactional(callback)` の混在パターンの DX を検証した。
+
+## 動作確認結果
+
+- カテゴリ一覧・タスク一覧・カテゴリでのフィルタリングが動作すること ✓
+- タスク完了（UPDATE）操作が正常に機能すること ✓（ただし FT17-F2 の制約あり）
+- `transactional()` 内の `IntegrityError` が `DatabaseIntegrityException` に変換されること ✓
+
+## 摩擦点
+
+### FT17-F1 (HIGH, バグ): SqlAlchemyQueryExecutor.write() が IntegrityError をキャッチしない
+
+`_BoundQueryExecutor.write()`（`transactional()` 内部で使われる）は FT16 で `IntegrityError` を
+`DatabaseIntegrityException` に変換するよう修正されたが、
+`SqlAlchemyQueryExecutor.write()`（直接呼び出し）は対応していない。
+
+同じ「INSERT が重複するケース」でも、使う API によって異なる例外型が飛ぶ：
+
+```python
+# 直接 write() → IntegrityError (SQLAlchemy)
+executor.write("INSERT INTO categories (name) VALUES (:name)", {"name": "dup"})
+
+# transactional() 内 write() → DatabaseIntegrityException (nene2)
+tx_manager.transactional(lambda ex: ex.write("INSERT INTO categories (name) VALUES (:name)", {"name": "dup"}))
+```
+
+UseCase 層でどちらの API を使うかによって `except` 節を変える必要があり、一貫性がない。
+
+**対応**: `SqlAlchemyQueryExecutor.write()` でも `IntegrityError` をキャッチして
+`DatabaseIntegrityException` にラップする。
+
+### FT17-F2 (HIGH, バグ): write() が UPDATE/DELETE で 0 行影響した場合に誤った値を返す
+
+`write()` は `result.lastrowid or result.rowcount` を返すが、SQLite では UPDATE/DELETE の後も
+`cursor.lastrowid` が前の INSERT の rowid を保持する。
+
+```python
+# DB に id=1 の行がある状態で
+result = executor.write("UPDATE items SET name = 'x' WHERE id = 999")  # 0行影響
+# result == 1 (前のINSERTのlastrowid) — 期待値は 0
+```
+
+`if affected == 0: raise NotFound` のパターンが正しく動かない。
+
+**対応**: SQL が `INSERT` で始まる場合のみ `lastrowid` を使い、UPDATE/DELETE は `rowcount` を返す。
+
+## まとめ
+
+ドメイン間連携（JOIN クエリ、カテゴリフィルタリング）は問題なく動作した。
+ただし `SqlAlchemyQueryExecutor.write()` に HIGH レベルのバグが2件あり:
+
+- FT17-F1: `IntegrityError` が `DatabaseIntegrityException` に変換されない（API 非対称）
+- FT17-F2: UPDATE/DELETE で 0 行影響した場合の戻り値が不正
+
+両方とも `_BoundQueryExecutor.write()` には修正済みだが、`SqlAlchemyQueryExecutor.write()` に未適用。

--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -41,7 +41,7 @@ class SqlAlchemyQueryExecutor(DatabaseQueryExecutorInterface):
 
         Return value semantics:
         - INSERT with AUTOINCREMENT/SERIAL column → ``lastrowid`` (the new row's PK, always > 0)
-        - INSERT without auto-PK, or multi-row INSERT → falls back to ``rowcount``
+        - INSERT without auto-PK, or multi-row INSERT → ``rowcount``
         - UPDATE / DELETE → ``rowcount`` (number of rows affected; 0 means nothing matched)
 
         Use the return value to detect missing rows::
@@ -53,7 +53,11 @@ class SqlAlchemyQueryExecutor(DatabaseQueryExecutorInterface):
         try:
             with self._engine.begin() as conn:
                 result = conn.execute(text(sql), params or {})
-                return result.lastrowid or result.rowcount
+                if sql.strip().upper().startswith("INSERT"):
+                    return result.lastrowid or result.rowcount
+                return result.rowcount
+        except IntegrityError as exc:
+            raise DatabaseIntegrityException(str(exc)) from exc
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
 
@@ -86,7 +90,9 @@ class _BoundQueryExecutor(DatabaseQueryExecutorInterface):
             raise DatabaseIntegrityException(str(exc)) from exc
         except OperationalError as exc:
             raise DatabaseConnectionException(str(exc)) from exc
-        return result.lastrowid or result.rowcount
+        if sql.strip().upper().startswith("INSERT"):
+            return result.lastrowid or result.rowcount
+        return result.rowcount
 
 
 class SqlAlchemyTransactionManager(DatabaseTransactionManagerInterface):

--- a/tests/nene2/database/test_transaction.py
+++ b/tests/nene2/database/test_transaction.py
@@ -7,6 +7,7 @@ from sqlalchemy.pool import StaticPool
 from nene2.database import (
     DatabaseIntegrityException,
     DatabaseQueryExecutorInterface,
+    SqlAlchemyQueryExecutor,
     SqlAlchemyTransactionManager,
 )
 
@@ -100,3 +101,37 @@ def test_transactional_rollback_on_integrity_error() -> None:
 
     rows = mgr.transactional(lambda ex: ex.fetch_all("SELECT * FROM items"))
     assert rows == []  # ロールバックされて何も残っていない
+
+
+def test_executor_write_raises_database_integrity_exception() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    executor = SqlAlchemyQueryExecutor(engine)
+    executor.write("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE)")
+    executor.write("INSERT INTO t VALUES (1, 'alice')")
+
+    with pytest.raises(DatabaseIntegrityException):
+        executor.write("INSERT INTO t VALUES (2, 'alice')")
+
+
+def test_write_returns_zero_for_update_no_match() -> None:
+    mgr = _manager()
+    mgr.transactional(lambda ex: ex.write("INSERT INTO items (name) VALUES ('alice')"))
+
+    affected = mgr.transactional(
+        lambda ex: ex.write("UPDATE items SET name = 'bob' WHERE id = 999")
+    )
+    assert affected == 0  # 0 行影響 → 0 を返す
+
+
+def test_write_returns_rowcount_for_update_match() -> None:
+    mgr = _manager()
+    mgr.transactional(lambda ex: ex.write("INSERT INTO items (name) VALUES ('alice')"))
+
+    affected = mgr.transactional(
+        lambda ex: ex.write("UPDATE items SET name = 'bob' WHERE name = 'alice'")
+    )
+    assert affected == 1


### PR DESCRIPTION
## Summary

FT17 (複数ドメイン連携) で発見した2件の HIGH バグへの対応:

**FT17-F1: IntegrityError ラップ漏れ**
- `_BoundQueryExecutor.write()` は IntegrityError を DatabaseIntegrityException に変換するが、`SqlAlchemyQueryExecutor.write()` は未対応だった
- 修正: `SqlAlchemyQueryExecutor.write()` でも IntegrityError をキャッチして DatabaseIntegrityException にラップ

**FT17-F2: UPDATE で 0 行影響した場合の戻り値バグ**
- `write()` が `lastrowid or rowcount` を返すため、SQLite では UPDATE/DELETE で 0 行影響した場合に前の INSERT の lastrowid が返る
- `if affected == 0: raise NotFound` パターンが正しく動かなかった
- 修正: SQL が INSERT で始まる場合のみ `lastrowid` を使用、UPDATE/DELETE は `rowcount` を直接返す

両方 `SqlAlchemyQueryExecutor.write()` と `_BoundQueryExecutor.write()` に適用済み。

Closes #212

## Test plan
- [ ] `uv run pytest` — 221 tests pass
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check` — no issues
- [ ] `uv run ruff format --check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)