### PR TITLE
feat: configure_for_testing() ヘルパー追加と RequestLoggingMiddleware に exclude_paths を追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-18.md
+++ b/docs/field-trials/2026-05-field-trial-18.md
@@ -1,0 +1,60 @@
+# Field Trial 18 — RequestLoggingMiddleware 実運用
+
+**Date:** 2026-05-20
+**App:** FT18 Request Logging API（structlog ログ・request_id 連携・JSON ログ形式検証）
+**Directory:** `/home/xi/docker/nene2-python-FT/ft18-request-logging/`
+**nene2-python version:** v1.7.0
+
+## 概要
+
+`RequestLoggingMiddleware` を `RequestIdMiddleware` と組み合わせて実際に動かし、
+ログ出力の内容・request_id との連携・テストでのログ検証方法を確認した。
+
+## 動作確認結果
+
+- `request.received` / `request.completed` のログが出力されること ✓
+- ログに `method`, `path`, `status_code`, `duration_ms` が含まれること ✓
+- `RequestIdMiddleware` と組み合わせると `request_id` がログに入ること ✓
+- ログに `request_id` が含まれ、レスポンスヘッダーの `X-Request-Id` と一致すること ✓
+
+## 摩擦点
+
+### FT18-F1 (MEDIUM, テスト容易性): structlog が pytest caplog で捕捉できない
+
+`RequestLoggingMiddleware` は structlog を使ってログを出力するが、
+structlog のデフォルト設定では Python stdlib の logging ハンドラーを経由せず
+直接 stdout に書き込む。
+
+そのため pytest の `caplog` では構造化ログを捕捉できない。
+テストで `structlog` のログを検証するには `capsys` で stdout を捕捉するか、
+structlog を stdlib logging に向ける設定変更が必要。
+
+```python
+# caplog では捕捉できない（摩擦）
+with caplog.at_level(logging.INFO, logger="nene2.middleware.request_logging"):
+    client.get("/health")
+assert len(caplog.records) == 0  # 常に 0 — ログが入らない
+```
+
+**対応案**: `nene2.log` に `configure_for_testing()` ヘルパーを追加し、
+テスト環境で `structlog` を stdlib logging ブリッジ経由で使える設定を提供する。
+
+### FT18-F2 (LOW, 拡張性): ログレベルをコンストラクタから変更できない
+
+`RequestLoggingMiddleware` は常に `logger.info()` を使う。
+ヘルスチェックなど高頻度のパスのログを `DEBUG` に落としたい場合や、
+特定パスのログを無効化したい場合にコンストラクタパラメータで設定できない。
+
+他のミドルウェア（`ThrottleMiddleware` の `exclude_paths` など）との一貫性が取れていない。
+
+**対応案**: `exclude_paths: list[str] | None = None` パラメータを追加して
+特定パスのログを無効化できるようにする。または `log_level` パラメータで
+デフォルトのログレベルを変更可能にする。
+
+## まとめ
+
+基本的なリクエストロギングは問題なく動作した。`RequestIdMiddleware` との連携も良好。
+摩擦はテスト時の `caplog` 非対応（F1: MEDIUM）と拡張性（F2: LOW）の2点。
+
+F1 は structlog の設計に起因するが、テスト用ヘルパーを提供することで改善できる。
+F2 は他のミドルウェアとの一貫性の問題。

--- a/src/nene2/log/__init__.py
+++ b/src/nene2/log/__init__.py
@@ -1,5 +1,5 @@
 """NENE2 structured logging setup (structlog)."""
 
-from .setup import setup_logging
+from .setup import configure_for_testing, setup_logging
 
-__all__ = ["setup_logging"]
+__all__ = ["configure_for_testing", "setup_logging"]

--- a/src/nene2/log/setup.py
+++ b/src/nene2/log/setup.py
@@ -3,12 +3,52 @@
 Call setup_logging() once at startup (in create_app).
 - production / test: JSON renderer
 - local (development): ConsoleRenderer with colors
+
+Call configure_for_testing() in conftest.py to make structlog output capturable
+by pytest's caplog fixture via the stdlib logging bridge.
 """
 
 import logging
 import sys
 
 import structlog
+
+
+def configure_for_testing() -> None:
+    """Configure structlog to route through stdlib logging so pytest caplog can capture it.
+
+    Call once in ``conftest.py`` (module level or in a session-scoped fixture) before
+    any test that uses ``caplog`` to assert on structlog output::
+
+        # conftest.py
+        from nene2.log import configure_for_testing
+
+        configure_for_testing()
+    """
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.StackInfoRenderer(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processor=structlog.dev.ConsoleRenderer(colors=False),
+    )
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+        root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
 
 
 def setup_logging(app_env: str = "local") -> None:

--- a/src/nene2/middleware/request_logging.py
+++ b/src/nene2/middleware/request_logging.py
@@ -13,9 +13,21 @@ logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    """Log each request and response with method, path, status, and duration."""
+    """Log each request and response with method, path, status, and duration.
+
+    Args:
+        exclude_paths: Paths to skip logging for (e.g. ``["/health"]``).
+            Useful for high-frequency health-check endpoints where log noise is unwanted.
+    """
+
+    def __init__(self, app: object, exclude_paths: list[str] | None = None) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._exclude_paths = set(exclude_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self._exclude_paths:
+            return await call_next(request)
+
         start = time.perf_counter()
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(

--- a/tests/nene2/middleware/test_request_logging.py
+++ b/tests/nene2/middleware/test_request_logging.py
@@ -39,3 +39,22 @@ def test_logging_does_not_remove_headers() -> None:
     client = TestClient(_make_app())
     response = client.get("/ping")
     assert "X-Request-Id" in response.headers
+
+
+def test_exclude_paths_passes_requests_through() -> None:
+    """exclude_paths に指定したパスへのリクエストがミドルウェアを通過すること"""
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware, exclude_paths=["/health"])
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+    @app.get("/items")
+    async def items() -> JSONResponse:
+        return JSONResponse([])
+
+    client = TestClient(app)
+    assert client.get("/health").status_code == 200
+    assert client.get("/items").status_code == 200


### PR DESCRIPTION
## Summary

FT18 (RequestLoggingMiddleware 実運用) で発見した2つの摩擦点への対応:

**FT18-F1 (#215): structlog を pytest caplog で捕捉できない**
- `nene2.log.configure_for_testing()` を追加
- `conftest.py` から一行で呼ぶことで structlog を stdlib logging 経由にルーティングし、`caplog` でログを捕捉可能に

**FT18-F2 (#216): ログレベル/パスをコンストラクタから設定できない**
- `RequestLoggingMiddleware` に `exclude_paths: list[str] | None = None` を追加
- `ThrottleMiddleware` などと同様のパターンで特定パスのログを無効化可能に

FT18 フィールドトライアルレポートを `docs/field-trials/2026-05-field-trial-18.md` に追加

Closes #215, #216

## Test plan
- [ ] `uv run pytest` — 222 tests pass
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check` — no issues
- [ ] `uv run ruff format --check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)