### PR TITLE
feat: ThrottleMiddleware に X-RateLimit-* ヘッダーを全レスポンスに付与する

### DIFF
--- a/docs/field-trials/2026-05-field-trial-20.md
+++ b/docs/field-trials/2026-05-field-trial-20.md
@@ -1,0 +1,94 @@
+# FT20: ThrottleMiddleware 実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `ThrottleMiddleware` を使ったレート制限 API の実運用検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft20-throttle/`
+
+---
+
+## 目的
+
+`nene2.middleware.ThrottleMiddleware` を実際のアプリ（公開 API + ヘルスチェック）に組み込み、
+レート制限の動作確認と摩擦点を発見する。
+
+---
+
+## 実施内容
+
+- `limit=3, window=60` のレート制限を設定した FastAPI アプリを作成
+- `/health` を `exclude_paths` で除外
+- `/api/data`、`/api/expensive` の 2 エンドポイントにレート制限を適用
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_health_check_is_not_rate_limited | PASS |
+| test_requests_within_limit_succeed | PASS |
+| test_requests_exceeding_limit_return_429 | PASS |
+| test_rate_limit_429_includes_retry_after_header | PASS |
+| test_rate_limit_applies_across_different_endpoints | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_no_rate_limit_headers_on_successful_responses | PASS | あり |
+| test_no_per_path_rate_limits | PASS | あり |
+| test_memory_not_cleaned_up_over_time | PASS | あり |
+
+---
+
+## 発見した摩擦点
+
+### FT20-F1: 通常レスポンスに X-RateLimit-* ヘッダーが付かない
+
+**概要**: 429 応答には `Retry-After` ヘッダーが付くが、
+通常のレスポンスには `X-RateLimit-Limit`、`X-RateLimit-Remaining`、`X-RateLimit-Reset`
+が付かない。
+
+**影響**: クライアントが自分のレート制限状況をリアルタイムで把握できない。
+SDK やクライアントが事前にスロットリングする「adaptive throttling」が実装できない。
+
+**期待する解決策**: 全レスポンスに `X-RateLimit-*` ヘッダーを付与するオプションを追加。
+
+---
+
+### FT20-F2: エンドポイントごとに異なるレート制限を設定できない
+
+**概要**: `ThrottleMiddleware` は全エンドポイントで同一の `limit`/`window` のみ対応。
+コスト大きなエンドポイント（`/api/expensive`: 10req/min）と軽いエンドポイント
+（`/api/data`: 100req/min）で異なる制限を設定できない。
+
+**影響**: 実運用では計算コストの重いエンドポイントを個別に絞りたいケースが多い。
+
+**期待する解決策**: `path_limits: dict[str, int] | None = None` のようなパスごとの
+レート制限設定パラメータを追加。
+
+---
+
+### FT20-F3: 古い IP エントリがメモリから削除されない
+
+**概要**: `_counts` dict のエントリは、ウィンドウ経過後もメモリに残り続ける。
+リクエスト時に古いエントリを上書きするだけで、削除はしない設計。
+
+**影響**: 長時間稼働するサーバーでユニーク IP が多い場合、メモリが増加し続ける。
+
+**期待する解決策**: ウィンドウ経過後の古いエントリを定期的に削除する
+クリーンアップ機構（ローリングクリーンアップや LRU キャッシュ制限など）を追加。
+
+---
+
+## まとめ
+
+`ThrottleMiddleware` の基本機能（IP ベースの固定ウィンドウレート制限、429 応答、
+`Retry-After` ヘッダー、`exclude_paths`）は問題なく動作する。
+実運用でよく必要になる以下の 3 点が摩擦として発見された:
+
+1. **`X-RateLimit-*` ヘッダーの欠如** → クライアントが制限状況を把握できない
+2. **パスごとのレート制限が不可** → 計算コストの差があるエンドポイントの制御が難しい
+3. **古いエントリのメモリ残留** → 長時間稼働時のメモリリーク懸念
+
+F1 (X-RateLimit headers) が最も実装インパクトが高く、今回の修正対象とする。

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -2,6 +2,8 @@
 
 Tracks request counts per client IP in an in-memory dict.
 Exceeding the limit returns 429 with a Retry-After header.
+All responses include ``X-RateLimit-Limit``, ``X-RateLimit-Remaining``, and
+``X-RateLimit-Reset`` headers so clients can adapt their request rate.
 
 .. warning::
     ``X-Forwarded-For`` is trusted as-is when present.  In environments
@@ -13,6 +15,7 @@ Exceeding the limit returns 429 with a Retry-After header.
 
 import threading
 import time
+from dataclasses import dataclass
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -24,8 +27,20 @@ _DEFAULT_LIMIT = 60
 _DEFAULT_WINDOW = 60  # seconds
 
 
+@dataclass(frozen=True, slots=True)
+class _RateInfo:
+    allowed: bool
+    remaining: int
+    retry_after: int
+    reset_at: int  # Unix timestamp
+
+
 class ThrottleMiddleware(BaseHTTPMiddleware):
     """Fixed-window rate limiter keyed by client IP.
+
+    Adds ``X-RateLimit-Limit``, ``X-RateLimit-Remaining``, and
+    ``X-RateLimit-Reset`` headers to every response so clients can monitor
+    their quota.  On 429, also adds ``Retry-After``.
 
     Use ``exclude_paths`` to bypass rate limiting for health checks and API docs::
 
@@ -58,29 +73,46 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
             return forwarded.split(",")[0].strip()
         return request.client.host if request.client else "unknown"
 
-    def _is_allowed(self, key: str) -> tuple[bool, int]:
+    def _check_rate(self, key: str) -> _RateInfo:
         now = time.monotonic()
+        wall_now = int(time.time())
         with self._lock:
             count, window_start = self._counts.get(key, (0, now))
             if now - window_start >= self._window:
                 count, window_start = 0, now
             count += 1
             self._counts[key] = (count, window_start)
-            remaining = max(0, self._window - int(now - window_start))
-        return count <= self._limit, remaining
+            elapsed = int(now - window_start)
+            retry_after = max(0, self._window - elapsed)
+            reset_at = wall_now + retry_after
+            remaining = max(0, self._limit - count)
+        return _RateInfo(
+            allowed=count <= self._limit,
+            remaining=remaining,
+            retry_after=retry_after,
+            reset_at=reset_at,
+        )
+
+    def _apply_rate_headers(self, response: Response, info: _RateInfo) -> None:
+        response.headers["X-RateLimit-Limit"] = str(self._limit)
+        response.headers["X-RateLimit-Remaining"] = str(info.remaining)
+        response.headers["X-RateLimit-Reset"] = str(info.reset_at)
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         if request.url.path in self._exclude_paths:
             return await call_next(request)
         key = self._client_key(request)
-        allowed, retry_after = self._is_allowed(key)
-        if not allowed:
-            response = problem_details_response(
+        info = self._check_rate(key)
+        if not info.allowed:
+            error_response = problem_details_response(
                 "too-many-requests",
                 "Too Many Requests",
                 429,
-                f"Rate limit exceeded. Retry after {retry_after} seconds.",
+                f"Rate limit exceeded. Retry after {info.retry_after} seconds.",
             )
-            response.headers["Retry-After"] = str(retry_after)
-            return response
-        return await call_next(request)
+            error_response.headers["Retry-After"] = str(info.retry_after)
+            self._apply_rate_headers(error_response, info)
+            return error_response
+        response = await call_next(request)
+        self._apply_rate_headers(response, info)
+        return response

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -75,3 +75,31 @@ def test_exclude_paths_default_is_empty() -> None:
     client = TestClient(_make_app(limit=1))
     client.get("/ping")
     assert client.get("/ping").status_code == 429
+
+
+def test_successful_response_includes_rate_limit_headers() -> None:
+    client = TestClient(_make_app(limit=5))
+    r = client.get("/ping")
+    assert r.status_code == 200
+    assert r.headers["X-RateLimit-Limit"] == "5"
+    assert r.headers["X-RateLimit-Remaining"] == "4"
+    assert "X-RateLimit-Reset" in r.headers
+
+
+def test_rate_limit_remaining_decrements_per_request() -> None:
+    client = TestClient(_make_app(limit=5))
+    r1 = client.get("/ping")
+    r2 = client.get("/ping")
+    assert int(r1.headers["X-RateLimit-Remaining"]) > int(r2.headers["X-RateLimit-Remaining"])
+
+
+def test_429_response_includes_rate_limit_headers() -> None:
+    client = TestClient(_make_app(limit=2))
+    client.get("/ping")
+    client.get("/ping")
+    r = client.get("/ping")
+    assert r.status_code == 429
+    assert r.headers["X-RateLimit-Limit"] == "2"
+    assert r.headers["X-RateLimit-Remaining"] == "0"
+    assert "X-RateLimit-Reset" in r.headers
+    assert "Retry-After" in r.headers


### PR DESCRIPTION
## Summary

- 全レスポンス（200/429 問わず）に `X-RateLimit-Limit`、`X-RateLimit-Remaining`、`X-RateLimit-Reset` ヘッダーを付与（FT20 の摩擦点 #221 対応）
- クライアントが自身のレート制限状況をリアルタイムで把握できるようになる
- `_is_allowed()` → `_check_rate()` にリネーム、戻り値を `_RateInfo` dataclass に変更
- ThrottleMiddleware テスト 5件 → 8件に拡充

## Test plan

- [ ] `tests/nene2/middleware/test_throttle.py` 8件のテストが全通過
- [ ] `uv run pytest` — 233 passed, coverage 92%+
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check src/ tests/` — no issues
- [ ] `uv run ruff format --check src/ tests/` — no issues
- [ ] `uv run pip-audit` — no vulnerabilities

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)