### PR TITLE
feat: SimpleDomainHandler ファクトリで DomainExceptionHandler の実装を簡略化する

### DIFF
--- a/docs/field-trials/2026-05-field-trial-21.md
+++ b/docs/field-trials/2026-05-field-trial-21.md
@@ -1,0 +1,104 @@
+# FT21: DomainExceptionHandler 実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `DomainExceptionHandlerProtocol` を使ったカスタム例外ハンドリングの実運用検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft21-domain-exception/`
+
+---
+
+## 目的
+
+`nene2.middleware.ErrorHandlerMiddleware` の `domain_handlers` オプションを使い、
+複数のカスタムドメイン例外を Problem Details に変換するパターンを検証する。
+
+---
+
+## 実施内容
+
+ブログ記事 API（`/posts/{post_id}`）を作成し、以下のドメイン例外を実装:
+
+- `PostNotFoundError` → 404 problem-details
+- `PostAccessDeniedError` → 403 problem-details
+- `PostAlreadyPublishedError` → 409 problem-details
+
+各例外に対応する `DomainExceptionHandlerProtocol` 実装クラスを作成し、
+`ErrorHandlerMiddleware(domain_handlers=[...])` に登録。
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_get_existing_post_returns_200 | PASS |
+| test_get_nonexistent_post_returns_404_problem_details | PASS |
+| test_get_other_users_post_returns_403 | PASS |
+| test_publish_already_published_returns_409 | PASS |
+| test_publish_unpublished_post_succeeds | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_no_base_class_for_domain_exception_handlers | PASS | あり |
+| test_handler_registration_requires_list_at_middleware_init | PASS | あり（軽微） |
+| test_unregistered_exception_falls_through_to_500 | PASS | あり（仕様だが摩擦） |
+
+---
+
+## 発見した摩擦点
+
+### FT21-F1: DomainExceptionHandler のボイラープレートが多い
+
+**概要**: `DomainExceptionHandlerProtocol` を満たすクラスを毎回 `handles()`/`handle()` の
+2 メソッドで実装する必要がある。多くのケースでパターンは同じ:
+1. `isinstance()` チェック
+2. `problem_details_response()` を呼ぶ
+
+**影響**: 3 つのドメイン例外に対して 3 つのハンドラークラスを書かなければならず、
+コード量が増える。
+
+**期待する解決策**:
+```python
+# 現状（各例外ごとにクラスが必要）
+class PostNotFoundHandler:
+    def handles(self, exc: Exception) -> bool:
+        return isinstance(exc, PostNotFoundError)
+    def handle(self, exc: Exception) -> Response:
+        return problem_details_response("post-not-found", "Not Found", 404)
+
+# 期待: ファクトリで一行
+handler = SimpleDomainHandler(PostNotFoundError, "post-not-found", "Post Not Found", 404)
+```
+
+---
+
+### FT21-F2: ハンドラーをミドルウェア初期化時にしか登録できない
+
+**概要**: `ErrorHandlerMiddleware` に `register_handler()` や `add_handler()` のような
+動的登録メソッドがないため、ミドルウェア初期化時に全ハンドラーをリストで渡す必要がある。
+
+**影響**: ドメインモジュールが分散している場合、一箇所に集めて渡す必要がある。
+（これは設計上妥当とも言えるが、大規模プロジェクトでは不便）
+
+**判断**: 初期化時一括登録は依存関係が明示的で好ましい設計のため、今回は修正しない。
+
+---
+
+### FT21-F3: 未登録ドメイン例外は 500 にフォールスルーする
+
+**概要**: `domain_handlers` への登録を忘れると 500 応答になる。
+ログを確認しないと原因が分からない。
+
+**判断**: `debug=True` で例外メッセージが `detail` に含まれるため、
+開発中は `ErrorHandlerMiddleware(debug=True)` を使えばデバッグ可能。
+ドキュメントに明記する対応が適切。
+
+---
+
+## まとめ
+
+`DomainExceptionHandlerProtocol` + `ErrorHandlerMiddleware` の組み合わせは機能するが、
+各例外ごとにクラスを 1 つ書く必要があるボイラープレートが摩擦の主な原因。
+
+`SimpleDomainHandler` ファクトリを追加することで DX が大幅に向上する（FT21-F1 → Issue化・修正対象）。

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -1,6 +1,6 @@
 """NENE2 middleware pipeline."""
 
-from .domain_exception import DomainExceptionHandlerProtocol
+from .domain_exception import DomainExceptionHandlerProtocol, SimpleDomainHandler
 from .error_handler import ErrorHandlerMiddleware
 from .request_id import RequestIdMiddleware, request_id_var
 from .request_logging import RequestLoggingMiddleware
@@ -10,6 +10,7 @@ from .throttle import ThrottleMiddleware
 
 __all__ = [
     "DomainExceptionHandlerProtocol",
+    "SimpleDomainHandler",
     "ErrorHandlerMiddleware",
     "RequestIdMiddleware",
     "RequestLoggingMiddleware",

--- a/src/nene2/middleware/domain_exception.py
+++ b/src/nene2/middleware/domain_exception.py
@@ -1,8 +1,11 @@
 """DomainExceptionHandlerProtocol — delegate domain errors to typed handlers."""
 
-from typing import Protocol, runtime_checkable
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
 
 from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
 
 
 @runtime_checkable
@@ -16,3 +19,64 @@ class DomainExceptionHandlerProtocol(Protocol):
     def handle(self, exc: Exception) -> Response:
         """Convert *exc* to an HTTP response. Called only when handles() is True."""
         ...
+
+
+class SimpleDomainHandler:
+    """Convenience handler that maps one exception class to a fixed Problem Details response.
+
+    Eliminates the boilerplate of implementing ``handles()`` and ``handle()`` for
+    simple cases where the entire response is determined by the exception type::
+
+        from nene2.middleware import SimpleDomainHandler
+
+        handlers = [
+            SimpleDomainHandler(PostNotFoundError, "post-not-found", "Post Not Found", 404),
+            SimpleDomainHandler(PostAccessDeniedError, "post-access-denied", "Access Denied", 403),
+        ]
+        app.add_middleware(ErrorHandlerMiddleware, domain_handlers=handlers)
+
+    When you need a dynamic ``detail`` or ``extra`` fields derived from the exception,
+    pass an ``extra_factory`` callable::
+
+        SimpleDomainHandler(
+            PostNotFoundError,
+            "post-not-found",
+            "Post Not Found",
+            404,
+            detail_factory=lambda exc: str(exc),
+            extra_factory=lambda exc: {"post_id": exc.post_id},
+        )
+    """
+
+    def __init__(
+        self,
+        exception_class: type[Exception],
+        problem_type: str,
+        title: str,
+        status: int,
+        detail: str | None = None,
+        *,
+        detail_factory: Callable[[Exception], str] | None = None,
+        extra_factory: Callable[[Exception], dict[str, Any]] | None = None,
+    ) -> None:
+        self._exception_class = exception_class
+        self._problem_type = problem_type
+        self._title = title
+        self._status = status
+        self._detail = detail
+        self._detail_factory = detail_factory
+        self._extra_factory = extra_factory
+
+    def handles(self, exc: Exception) -> bool:
+        return isinstance(exc, self._exception_class)
+
+    def handle(self, exc: Exception) -> Response:
+        detail = self._detail_factory(exc) if self._detail_factory else self._detail
+        extra = self._extra_factory(exc) if self._extra_factory else None
+        return problem_details_response(
+            self._problem_type,
+            self._title,
+            self._status,
+            detail,
+            extra,
+        )

--- a/tests/nene2/middleware/test_simple_domain_handler.py
+++ b/tests/nene2/middleware/test_simple_domain_handler.py
@@ -1,0 +1,100 @@
+"""Tests for SimpleDomainHandler."""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.middleware import ErrorHandlerMiddleware, SimpleDomainHandler
+from nene2.middleware.domain_exception import DomainExceptionHandlerProtocol
+
+
+class _NotFoundError(Exception):
+    def __init__(self, resource_id: int) -> None:
+        self.resource_id = resource_id
+        super().__init__(f"Resource {resource_id} not found")
+
+
+class _AccessDeniedError(Exception):
+    pass
+
+
+def _make_app(*handlers: DomainExceptionHandlerProtocol) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(ErrorHandlerMiddleware, domain_handlers=list(handlers))
+
+    @app.get("/not-found")
+    async def raise_not_found() -> JSONResponse:
+        raise _NotFoundError(42)
+
+    @app.get("/access-denied")
+    async def raise_access_denied() -> JSONResponse:
+        raise _AccessDeniedError("forbidden")
+
+    return app
+
+
+def test_simple_handler_satisfies_protocol() -> None:
+    handler = SimpleDomainHandler(_NotFoundError, "not-found", "Not Found", 404)
+    assert isinstance(handler, DomainExceptionHandlerProtocol)
+
+
+def test_simple_handler_handles_correct_exception_class() -> None:
+    handler = SimpleDomainHandler(_NotFoundError, "not-found", "Not Found", 404)
+    assert handler.handles(_NotFoundError(1)) is True
+    assert handler.handles(_AccessDeniedError()) is False
+
+
+def test_simple_handler_returns_problem_details_response() -> None:
+    handler = SimpleDomainHandler(_NotFoundError, "not-found", "Not Found", 404)
+    client = TestClient(_make_app(handler), raise_server_exceptions=False)
+    r = client.get("/not-found")
+    assert r.status_code == 404
+    body = r.json()
+    assert "not-found" in body["type"]
+    assert body["status"] == 404
+    assert "problem+json" in r.headers["content-type"]
+
+
+def test_simple_handler_with_static_detail() -> None:
+    handler = SimpleDomainHandler(
+        _NotFoundError, "not-found", "Not Found", 404, detail="Resource missing"
+    )
+    client = TestClient(_make_app(handler), raise_server_exceptions=False)
+    r = client.get("/not-found")
+    assert r.json()["detail"] == "Resource missing"
+
+
+def test_simple_handler_with_detail_factory() -> None:
+    handler = SimpleDomainHandler(
+        _NotFoundError,
+        "not-found",
+        "Not Found",
+        404,
+        detail_factory=str,
+    )
+    client = TestClient(_make_app(handler), raise_server_exceptions=False)
+    r = client.get("/not-found")
+    assert "Resource 42 not found" in r.json()["detail"]
+
+
+def test_simple_handler_with_extra_factory() -> None:
+    handler = SimpleDomainHandler(
+        _NotFoundError,
+        "not-found",
+        "Not Found",
+        404,
+        extra_factory=lambda exc: {"resource_id": exc.resource_id},  # type: ignore[union-attr]
+    )
+    client = TestClient(_make_app(handler), raise_server_exceptions=False)
+    r = client.get("/not-found")
+    assert r.json()["resource_id"] == 42
+
+
+def test_multiple_simple_handlers_registered_together() -> None:
+    handlers = [
+        SimpleDomainHandler(_NotFoundError, "not-found", "Not Found", 404),
+        SimpleDomainHandler(_AccessDeniedError, "access-denied", "Access Denied", 403),
+    ]
+    client = TestClient(_make_app(*handlers), raise_server_exceptions=False)
+    assert client.get("/not-found").status_code == 404
+    assert client.get("/access-denied").status_code == 403


### PR DESCRIPTION
## Summary

- `SimpleDomainHandler` クラスを追加（FT21 の摩擦点 #225 対応）
- `exception_class`、`problem_type`、`title`、`status` を渡すだけでドメイン例外ハンドラーを作成できる
- `detail_factory` / `extra_factory` コールバックで動的フィールドにも対応
- `nene2.middleware` から `SimpleDomainHandler` をエクスポート

```python
# Before (各例外にクラスが必要)
class PostNotFoundHandler:
    def handles(self, exc): return isinstance(exc, PostNotFoundError)
    def handle(self, exc): return problem_details_response("post-not-found", "Not Found", 404)

# After
SimpleDomainHandler(PostNotFoundError, "post-not-found", "Post Not Found", 404)
```

## Test plan

- [ ] `tests/nene2/middleware/test_simple_domain_handler.py` 7件のテストが全通過
- [ ] `uv run pytest` — 240 passed, coverage 92%+
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check src/ tests/` — no issues
- [ ] `uv run ruff format --check src/ tests/` — no issues
- [ ] `uv run pip-audit` — no vulnerabilities

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)