### PR TITLE
feat: CompositeHealthCheck で複数ヘルスチェックを集約できるようにする

### DIFF
--- a/docs/field-trials/2026-05-field-trial-22.md
+++ b/docs/field-trials/2026-05-field-trial-22.md
@@ -1,0 +1,87 @@
+# FT22: HealthCheckProtocol 実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `HealthCheckProtocol` を使ったヘルスチェックエンドポイントの実運用検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft22-health-check/`
+
+---
+
+## 目的
+
+`nene2.http.HealthCheckProtocol` と `DatabaseHealthCheck` を使って
+DB + 外部サービスを組み合わせた `/health` エンドポイントを実装するパターンを検証する。
+
+---
+
+## 実施内容
+
+- SQLite in-memory DB の `DatabaseHealthCheck` を組み込み
+- 外部 API の可用性を表す `ExternalApiHealthCheck`（モック）を実装
+- 両者を組み合わせる `CompositeCheck`（手動実装）を作成
+- `/health` エンドポイントを手動で FastAPI に登録
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_health_returns_200_when_all_checks_pass | PASS |
+| test_health_returns_503_when_service_unavailable | PASS |
+| test_database_check_passes | PASS |
+| test_api_data_endpoint_works | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_no_composite_health_check_provided | PASS | あり |
+| test_health_endpoint_not_integrated_with_framework | PASS | あり |
+| test_health_status_checks_is_flat_string_dict | PASS | あり（軽微） |
+
+---
+
+## 発見した摩擦点
+
+### FT22-F1: 複数チェックを集約する CompositeHealthCheck がない
+
+**概要**: DB チェック + 外部サービスチェックなど複数の `HealthCheckProtocol` を
+組み合わせる場合、毎回集約クラスを手書きする必要がある。
+
+**影響**: 実運用では複数チェックの組み合わせが一般的で、
+その度に同じ集約ロジックを再実装することになる。
+
+**期待する解決策**: `CompositeHealthCheck(checks: list[HealthCheckProtocol])` クラスを
+`nene2.http` に追加する。
+
+---
+
+### FT22-F2: /health エンドポイントの FastAPI 登録ヘルパーがない
+
+**概要**: `HealthCheckProtocol` を実装しても、それを `/health` エンドポイントとして
+FastAPI に登録する仕組みがない。毎回同じパターンのエンドポイント定義を手書きする必要がある。
+
+**影響**: ボイラープレートが多い（status_code 分岐、JSON レスポンス形式など）。
+
+**期待する解決策**: `CompositeHealthCheck` 自体に FastAPI ルーターを生成するメソッドを
+追加するより、`CompositeHealthCheck` があれば残りは app.py 側で 5 行で済むため、
+今回は F1 の修正で十分と判断。
+
+---
+
+### FT22-F3: HealthStatus.checks が dict[str, str] のみ（軽微）
+
+**概要**: `HealthStatus.checks` の型が `dict[str, str]` のため、
+レイテンシや接続プール情報などの構造化詳細を含めることができない。
+
+**判断**: RFC ヘルスチェックの標準的な形式は文字列ステータスで十分なため、
+現状の型で問題なし。要件があれば `extra` フィールドを追加する方向で対応。
+
+---
+
+## まとめ
+
+`HealthCheckProtocol` と `DatabaseHealthCheck` は機能するが、
+複数チェックの集約クラスがないため実運用で毎回同じコードを書く必要がある。
+
+`CompositeHealthCheck` の追加が最も有効な改善（FT22-F1 → Issue化・修正対象）。

--- a/src/nene2/http/__init__.py
+++ b/src/nene2/http/__init__.py
@@ -1,10 +1,11 @@
 """HTTP helpers — JSON responses, pagination, problem details, health."""
 
-from .health import HealthCheckProtocol, HealthStatus
+from .health import CompositeHealthCheck, HealthCheckProtocol, HealthStatus
 from .pagination import PaginationQuery, PaginationQueryParser, PaginationResponse
 from .problem_details import configure_problem_details, problem_details_response
 
 __all__ = [
+    "CompositeHealthCheck",
     "HealthCheckProtocol",
     "HealthStatus",
     "PaginationQuery",

--- a/src/nene2/http/health.py
+++ b/src/nene2/http/health.py
@@ -1,7 +1,7 @@
-"""HealthCheckProtocol and HealthStatus — framework health check contract."""
+"""HealthCheckProtocol, HealthStatus, and CompositeHealthCheck."""
 
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,7 +14,35 @@ class HealthStatus:
         return self.status == "ok"
 
 
+@runtime_checkable
 class HealthCheckProtocol(Protocol):
     """Contract for application health checks."""
 
     def check(self) -> HealthStatus: ...
+
+
+class CompositeHealthCheck:
+    """Aggregate multiple :class:`HealthCheckProtocol` instances into one.
+
+    Returns ``HealthStatus(status="ok")`` only when all checks pass.
+    Any failing check sets the overall status to ``"error"``::
+
+        from nene2.http import CompositeHealthCheck
+
+        composite = CompositeHealthCheck([db_check, external_api_check])
+        status = composite.check()
+        # HealthStatus(status="ok", checks={"database": "ok", "external_api": "ok"})
+    """
+
+    def __init__(self, checks: list[HealthCheckProtocol]) -> None:
+        self._checks = checks
+
+    def check(self) -> HealthStatus:
+        merged: dict[str, str] = {}
+        overall = "ok"
+        for health_check in self._checks:
+            result = health_check.check()
+            merged.update(result.checks)
+            if not result.is_healthy:
+                overall = "error"
+        return HealthStatus(status=overall, checks=merged)

--- a/tests/nene2/http/test_health.py
+++ b/tests/nene2/http/test_health.py
@@ -1,0 +1,58 @@
+"""Tests for HealthCheckProtocol, HealthStatus, and CompositeHealthCheck."""
+
+from nene2.http import CompositeHealthCheck, HealthCheckProtocol, HealthStatus
+
+
+class _OkCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="ok", checks={"service_a": "ok"})
+
+
+class _ErrorCheck:
+    def check(self) -> HealthStatus:
+        return HealthStatus(status="error", checks={"service_b": "error"})
+
+
+def test_health_status_is_healthy_when_ok() -> None:
+    assert HealthStatus(status="ok").is_healthy is True
+
+
+def test_health_status_is_not_healthy_when_error() -> None:
+    assert HealthStatus(status="error").is_healthy is False
+
+
+def test_composite_returns_ok_when_all_checks_pass() -> None:
+    class _OkCheck2:
+        def check(self) -> HealthStatus:
+            return HealthStatus(status="ok", checks={"service_b": "ok"})
+
+    composite = CompositeHealthCheck([_OkCheck(), _OkCheck2()])
+    result = composite.check()
+    assert result.is_healthy is True
+    assert result.status == "ok"
+
+
+def test_composite_returns_error_when_any_check_fails() -> None:
+    composite = CompositeHealthCheck([_OkCheck(), _ErrorCheck()])
+    result = composite.check()
+    assert result.is_healthy is False
+    assert result.status == "error"
+
+
+def test_composite_merges_all_checks() -> None:
+    composite = CompositeHealthCheck([_OkCheck(), _ErrorCheck()])
+    result = composite.check()
+    assert "service_a" in result.checks
+    assert "service_b" in result.checks
+
+
+def test_composite_satisfies_protocol() -> None:
+    composite = CompositeHealthCheck([_OkCheck()])
+    assert isinstance(composite, HealthCheckProtocol)
+
+
+def test_composite_with_empty_checks_returns_ok() -> None:
+    composite = CompositeHealthCheck([])
+    result = composite.check()
+    assert result.is_healthy is True
+    assert result.checks == {}


### PR DESCRIPTION
## Summary

- `CompositeHealthCheck` クラスを追加（FT22 の摩擦点 #227 対応）
- `list[HealthCheckProtocol]` を受け取り、全チェックの結果を集約
- 全チェックが ok → status="ok"、1 つでも失敗 → status="error"
- `HealthCheckProtocol` に `@runtime_checkable` を追加

```python
# Before: 毎回集約ロジックを手書き
# After:
composite = CompositeHealthCheck([db_check, external_api_check])
status = composite.check()
```

## Test plan

- [ ] `tests/nene2/http/test_health.py` 7件のテストが全通過
- [ ] `uv run pytest` — 247 passed
- [ ] `uv run mypy src/` — no issues
- [ ] `uv run ruff check src/ tests/` — no issues

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)