### PR TITLE
feat: get_request_id() Depends ヘルパーを追加 (#234)

### DIFF
--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -2,7 +2,7 @@
 
 from .domain_exception import DomainExceptionHandlerProtocol, SimpleDomainHandler
 from .error_handler import ErrorHandlerMiddleware
-from .request_id import RequestIdMiddleware, request_id_var
+from .request_id import RequestIdMiddleware, get_request_id, request_id_var
 from .request_logging import RequestLoggingMiddleware
 from .request_size_limit import RequestSizeLimitMiddleware
 from .security_headers import SecurityHeadersMiddleware
@@ -13,6 +13,7 @@ __all__ = [
     "SimpleDomainHandler",
     "ErrorHandlerMiddleware",
     "RequestIdMiddleware",
+    "get_request_id",
     "RequestLoggingMiddleware",
     "RequestSizeLimitMiddleware",
     "SecurityHeadersMiddleware",

--- a/src/nene2/middleware/request_id.py
+++ b/src/nene2/middleware/request_id.py
@@ -30,6 +30,24 @@ def _validated_request_id(value: str | None) -> str:
     return str(uuid.uuid4())
 
 
+def get_request_id() -> str:
+    """FastAPI ``Depends``-compatible helper that returns the current request ID.
+
+    Use this in route handlers to inject the request ID via dependency injection::
+
+        from nene2.middleware import get_request_id
+
+
+        @app.get("/")
+        async def handler(request_id: str = Depends(get_request_id)) -> JSONResponse:
+            return JSONResponse({"request_id": request_id})
+
+    Returns an empty string when called outside of a request context
+    (e.g., in tests without :class:`RequestIdMiddleware`).
+    """
+    return request_id_var.get()
+
+
 class RequestIdMiddleware(BaseHTTPMiddleware):
     """Generate or forward X-Request-Id and expose it via contextvars.
 

--- a/tests/nene2/middleware/test_request_id.py
+++ b/tests/nene2/middleware/test_request_id.py
@@ -2,11 +2,12 @@
 
 import re
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from nene2.middleware import RequestIdMiddleware, request_id_var
+import nene2.middleware
+from nene2.middleware import RequestIdMiddleware, get_request_id, request_id_var
 
 _UUID_V4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 
@@ -67,3 +68,27 @@ def test_each_request_gets_unique_id() -> None:
     client = TestClient(_make_app())
     ids = {client.get("/ping").headers["X-Request-Id"] for _ in range(5)}
     assert len(ids) == 5
+
+
+def test_get_request_id_returns_empty_outside_request_context() -> None:
+    assert get_request_id() == ""
+
+
+def test_get_request_id_via_depends_returns_current_id() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/with-depends")
+    async def handler(request_id: str = Depends(get_request_id)) -> JSONResponse:
+        return JSONResponse({"request_id": request_id})
+
+    client = TestClient(app)
+    response = client.get("/with-depends")
+    body = response.json()
+    assert _UUID_V4_RE.match(body["request_id"])
+    assert body["request_id"] == response.headers["X-Request-Id"]
+
+
+def test_get_request_id_exportable_from_nene2_middleware() -> None:
+    assert hasattr(nene2.middleware, "get_request_id")
+    assert callable(nene2.middleware.get_request_id)


### PR DESCRIPTION
## Summary
- FT25 (RequestIdMiddleware フィールドトライアル) で発見した摩擦点 FT25-F2 の修正
- `get_request_id()` ヘルパー関数を `nene2.middleware` からエクスポートするよう追加
- FastAPI の依存性注入パターンで `Depends(get_request_id)` として使用可能
- 外部リクエストコンテキスト (テスト等) では空文字列を返す

## Test plan
- [ ] `tests/nene2/middleware/test_request_id.py` に 3 つの新テスト追加、全 9 テスト PASS
- [ ] pytest 258 passed, coverage 92.84% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues
- [ ] pip-audit: no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)