### PR TITLE
feat: setup_logging() に log_level パラメータを追加 (#236)

### DIFF
--- a/src/nene2/log/setup.py
+++ b/src/nene2/log/setup.py
@@ -51,7 +51,7 @@ def configure_for_testing() -> None:
     root.setLevel(logging.DEBUG)
 
 
-def setup_logging(app_env: str = "local") -> None:
+def setup_logging(app_env: str = "local", log_level: str = "INFO") -> None:
     shared_processors: list[structlog.types.Processor] = [
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
@@ -86,4 +86,4 @@ def setup_logging(app_env: str = "local") -> None:
     root = logging.getLogger()
     root.handlers.clear()
     root.addHandler(handler)
-    root.setLevel(logging.INFO)
+    root.setLevel(getattr(logging, log_level.upper(), logging.INFO))

--- a/tests/nene2/log/test_setup.py
+++ b/tests/nene2/log/test_setup.py
@@ -1,0 +1,49 @@
+"""Tests for nene2.log.setup."""
+
+import logging
+
+from nene2.config import AppSettings
+from nene2.log import setup_logging
+
+
+def test_setup_logging_defaults_to_info_level() -> None:
+    setup_logging()
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_setup_logging_accepts_debug_level() -> None:
+    setup_logging(log_level="DEBUG")
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_setup_logging_accepts_warning_level() -> None:
+    setup_logging(log_level="WARNING")
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_setup_logging_accepts_error_level() -> None:
+    setup_logging(log_level="ERROR")
+    assert logging.getLogger().level == logging.ERROR
+
+
+def test_setup_logging_case_insensitive_level() -> None:
+    setup_logging(log_level="debug")
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_setup_logging_integrates_with_app_settings_log_level() -> None:
+    settings = AppSettings(log_level="DEBUG")
+    setup_logging(app_env=settings.app_env, log_level=settings.log_level)
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_setup_logging_local_env_uses_console_renderer() -> None:
+    setup_logging(app_env="local")
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+
+
+def test_setup_logging_production_env_uses_json_renderer() -> None:
+    setup_logging(app_env="production")
+    root = logging.getLogger()
+    assert len(root.handlers) == 1


### PR DESCRIPTION
## Summary
- FT26 (structlog 統合検証) で発見した摩擦点 FT26-F1 の修正
- `setup_logging(app_env, log_level="INFO")` に `log_level` パラメータを追加
- `AppSettings.log_level` と直接連携できるように — ボイラープレート不要
- `setup_logging(app_env=settings.app_env, log_level=settings.log_level)` で完結

## Test plan
- [ ] `tests/nene2/log/test_setup.py` に 8 テスト追加、全 PASS
- [ ] pytest 266 passed, coverage 92.97% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues
- [ ] pip-audit: no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)