### PR TITLE
fix: ThrottleMiddleware の古いエントリを定期クリーンアップする (#223)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-27.md
+++ b/docs/field-trials/2026-05-field-trial-27.md
@@ -1,0 +1,66 @@
+# FT27: ThrottleMiddleware 長時間運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `ThrottleMiddleware` の長時間稼働時のメモリ蓄積問題を検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft27-throttle-cleanup/`
+
+---
+
+## 目的
+
+`ThrottleMiddleware` の `_counts` ディクショナリに古いエントリが蓄積する問題（Issue #223）を実証し、
+修正方針を検討する。
+
+---
+
+## 実施内容
+
+- 複数 IP からのリクエストシミュレーション
+- ウィンドウ経過後のエントリ残存を確認
+- クリーンアップ機能の有無を検証
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_ping_returns_200 | PASS |
+| test_rate_limit_headers_present | PASS |
+| test_rate_limit_exceeded_returns_429 | PASS |
+| test_different_ips_have_separate_counters | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_stale_entries_accumulate_in_memory | PASS | あり（バグ） |
+| test_no_cleanup_method_exists_on_throttle_middleware | PASS | あり |
+
+---
+
+## 発見した摩擦点
+
+### FT27-F1: 古いエントリが _counts から削除されない（Issue #223）
+
+**概要**: 異なるクライアント IP からリクエストが来るたびに `_counts` にエントリが追加されるが、
+ウィンドウ期間が過ぎても古いエントリは削除されない。
+長時間稼働・多数の異なるクライアントが存在する環境ではメモリが際限なく増加する。
+
+**確認した動作**:
+```python
+# 10 IP のエントリを作成 → window (1秒) 経過後も 10 エントリが残る
+# 新しい IP のリクエスト後も 11 エントリ (10 古い + 1 新しい)
+```
+
+**修正方針**: `_check_rate()` 内で定期的にクリーンアップを実施する。
+`_last_cleanup` タイムスタンプを持ち、`window` 秒経過したときに期限切れエントリを一括削除する。
+
+---
+
+## まとめ
+
+`ThrottleMiddleware` の基本機能は正常に動作する。
+
+摩擦点:
+1. **古いエントリのメモリ蓄積** → Issue #223 として登録済み、修正対象

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -66,6 +66,7 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         self._exclude_paths = set(exclude_paths or [])
         self._counts: dict[str, tuple[int, float]] = {}
         self._lock = threading.Lock()
+        self._last_cleanup: float = 0.0
 
     def _client_key(self, request: Request) -> str:
         forwarded = request.headers.get("X-Forwarded-For")
@@ -73,10 +74,20 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
             return forwarded.split(",")[0].strip()
         return request.client.host if request.client else "unknown"
 
+    def _evict_stale(self, now: float) -> None:
+        if now - self._last_cleanup < self._window:
+            return
+        self._last_cleanup = now
+        cutoff = now - self._window
+        stale = [k for k, (_, ws) in self._counts.items() if ws < cutoff]
+        for k in stale:
+            del self._counts[k]
+
     def _check_rate(self, key: str) -> _RateInfo:
         now = time.monotonic()
         wall_now = int(time.time())
         with self._lock:
+            self._evict_stale(now)
             count, window_start = self._counts.get(key, (0, now))
             if now - window_start >= self._window:
                 count, window_start = 0, now

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -1,5 +1,7 @@
 """Tests for ThrottleMiddleware."""
 
+import time
+
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
@@ -103,3 +105,21 @@ def test_429_response_includes_rate_limit_headers() -> None:
     assert r.headers["X-RateLimit-Remaining"] == "0"
     assert "X-RateLimit-Reset" in r.headers
     assert "Retry-After" in r.headers
+
+
+def test_stale_entries_are_evicted_after_window_expires() -> None:
+    app = FastAPI()
+    middleware = ThrottleMiddleware(app, limit=100, window=1)
+
+    for i in range(10):
+        middleware._check_rate(f"192.168.1.{i}")
+
+    assert len(middleware._counts) == 10
+
+    time.sleep(1.1)
+
+    # 新しいリクエストでクリーンアップがトリガーされる
+    middleware._check_rate("10.0.0.99")
+
+    # 古い 10 エントリは削除され、新しい 1 エントリのみ残る
+    assert len(middleware._counts) == 1


### PR DESCRIPTION
## Summary
- FT27 (ThrottleMiddleware 長時間運用検証) で実証した Issue #223 の修正
- `_evict_stale()` メソッドを追加: ウィンドウ期間ごとに期限切れエントリを一括削除
- `_check_rate()` 内で `_evict_stale()` を呼び出し、長時間稼働でもメモリが際限なく増加しなくなった
- ロックの内側で実行し、スレッドセーフを維持

## Test plan
- [ ] `test_stale_entries_are_evicted_after_window_expires` 追加 — 全 9 テスト PASS
- [ ] pytest 267 passed, coverage 93.03% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues
- [ ] pip-audit: no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)