### PR TITLE
feat: ThrottleMiddleware に path_limits パラメータを追加 (#222)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-28.md
+++ b/docs/field-trials/2026-05-field-trial-28.md
@@ -1,0 +1,54 @@
+# FT28: ThrottleMiddleware パスごとのレート制限検証
+
+**日付**: 2026-05-20
+**テーマ**: `ThrottleMiddleware` のパスごとのレート制限（Issue #222）
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft28-path-throttle/`
+
+---
+
+## 目的
+
+重いエンドポイントだけ厳しいレート制限をかけたい実運用ニーズを検証する。
+
+---
+
+## 実施内容
+
+- `path_limits` パラメータの不在を確認
+- 現状では全エンドポイントで同じ `limit`/`window` しか設定できないことを実証
+
+---
+
+## テスト結果
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_throttle_middleware_does_not_support_path_limits | PASS | あり |
+| test_workaround_requires_multiple_middlewares | PASS | あり |
+
+---
+
+## 発見した摩擦点
+
+### FT28-F1: ThrottleMiddleware がパスごとのレート制限をサポートしない（Issue #222）
+
+**概要**: 全エンドポイントで同じ `limit`/`window` しか設定できない。
+`/api/expensive` だけ `limit=10` にして残りは `limit=100` にする、という設定ができない。
+
+**期待する使い方**:
+```python
+app.add_middleware(
+    ThrottleMiddleware,
+    limit=100,
+    window=60,
+    path_limits={"/api/expensive": 10, "/api/search": 30},
+)
+```
+
+---
+
+## まとめ
+
+摩擦点:
+1. **`path_limits` 未対応** → Issue #222 として登録済み、修正対象

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -42,14 +42,19 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
     ``X-RateLimit-Reset`` headers to every response so clients can monitor
     their quota.  On 429, also adds ``Retry-After``.
 
-    Use ``exclude_paths`` to bypass rate limiting for health checks and API docs::
+    Use ``path_limits`` to apply stricter limits on specific paths::
 
         app.add_middleware(
             ThrottleMiddleware,
-            limit=60,
+            limit=100,
             window=60,
+            path_limits={"/api/expensive": 10, "/api/search": 30},
             exclude_paths=["/health", "/docs", "/openapi.json"],
         )
+
+    Path-limited endpoints are tracked independently from the global counter
+    (the key includes the path, so ``/api/expensive`` quota is separate from
+    the default quota for other paths).
     """
 
     def __init__(
@@ -58,11 +63,13 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         *,
         limit: int = _DEFAULT_LIMIT,
         window: int = _DEFAULT_WINDOW,
+        path_limits: dict[str, int] | None = None,
         exclude_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._limit = limit
         self._window = window
+        self._path_limits: dict[str, int] = path_limits or {}
         self._exclude_paths = set(exclude_paths or [])
         self._counts: dict[str, tuple[int, float]] = {}
         self._lock = threading.Lock()
@@ -83,7 +90,7 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         for k in stale:
             del self._counts[k]
 
-    def _check_rate(self, key: str) -> _RateInfo:
+    def _check_rate(self, key: str, limit: int) -> _RateInfo:
         now = time.monotonic()
         wall_now = int(time.time())
         with self._lock:
@@ -96,24 +103,31 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
             elapsed = int(now - window_start)
             retry_after = max(0, self._window - elapsed)
             reset_at = wall_now + retry_after
-            remaining = max(0, self._limit - count)
+            remaining = max(0, limit - count)
         return _RateInfo(
-            allowed=count <= self._limit,
+            allowed=count <= limit,
             remaining=remaining,
             retry_after=retry_after,
             reset_at=reset_at,
         )
 
-    def _apply_rate_headers(self, response: Response, info: _RateInfo) -> None:
-        response.headers["X-RateLimit-Limit"] = str(self._limit)
+    def _apply_rate_headers(self, response: Response, info: _RateInfo, limit: int) -> None:
+        response.headers["X-RateLimit-Limit"] = str(limit)
         response.headers["X-RateLimit-Remaining"] = str(info.remaining)
         response.headers["X-RateLimit-Reset"] = str(info.reset_at)
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in self._exclude_paths:
+        path = request.url.path
+        if path in self._exclude_paths:
             return await call_next(request)
-        key = self._client_key(request)
-        info = self._check_rate(key)
+        client = self._client_key(request)
+        if path in self._path_limits:
+            effective_limit = self._path_limits[path]
+            key = f"{client}:{path}"
+        else:
+            effective_limit = self._limit
+            key = client
+        info = self._check_rate(key, effective_limit)
         if not info.allowed:
             error_response = problem_details_response(
                 "too-many-requests",
@@ -122,8 +136,8 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
                 f"Rate limit exceeded. Retry after {info.retry_after} seconds.",
             )
             error_response.headers["Retry-After"] = str(info.retry_after)
-            self._apply_rate_headers(error_response, info)
+            self._apply_rate_headers(error_response, info, effective_limit)
             return error_response
         response = await call_next(request)
-        self._apply_rate_headers(response, info)
+        self._apply_rate_headers(response, info, effective_limit)
         return response

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -107,19 +107,84 @@ def test_429_response_includes_rate_limit_headers() -> None:
     assert "Retry-After" in r.headers
 
 
+def test_path_limits_override_default_limit() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ThrottleMiddleware,
+        limit=100,
+        window=60,
+        path_limits={"/expensive": 2},
+    )
+
+    @app.get("/expensive")
+    async def expensive() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/cheap")
+    async def cheap() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.get("/expensive").status_code == 200
+    assert client.get("/expensive").status_code == 200
+    assert client.get("/expensive").status_code == 429
+    # cheap は path_limits に含まれないので 100 req まで許可
+    assert client.get("/cheap").status_code == 200
+
+
+def test_path_limit_and_default_limit_are_independent_counters() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ThrottleMiddleware,
+        limit=2,
+        window=60,
+        path_limits={"/special": 1},
+    )
+
+    @app.get("/special")
+    async def special() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/normal")
+    async def normal() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    # /special: limit=1
+    assert client.get("/special").status_code == 200
+    assert client.get("/special").status_code == 429
+    # /normal: limit=2 (別カウンター)
+    assert client.get("/normal").status_code == 200
+    assert client.get("/normal").status_code == 200
+    assert client.get("/normal").status_code == 429
+
+
+def test_path_limit_reflected_in_x_ratelimit_limit_header() -> None:
+    app = FastAPI()
+    app.add_middleware(ThrottleMiddleware, limit=100, window=60, path_limits={"/ping": 5})
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    r = client.get("/ping")
+    assert r.headers["X-RateLimit-Limit"] == "5"
+
+
 def test_stale_entries_are_evicted_after_window_expires() -> None:
     app = FastAPI()
     middleware = ThrottleMiddleware(app, limit=100, window=1)
 
     for i in range(10):
-        middleware._check_rate(f"192.168.1.{i}")
+        middleware._check_rate(f"192.168.1.{i}", 100)
 
     assert len(middleware._counts) == 10
 
     time.sleep(1.1)
 
     # 新しいリクエストでクリーンアップがトリガーされる
-    middleware._check_rate("10.0.0.99")
+    middleware._check_rate("10.0.0.99", 100)
 
     # 古い 10 エントリは削除され、新しい 1 エントリのみ残る
     assert len(middleware._counts) == 1


### PR DESCRIPTION
## Summary
- FT28 (パスごとのレート制限検証) で実証した Issue #222 の修正
- `path_limits: dict[str, int]` パラメータを追加: `{"/api/expensive": 10, "/api/search": 30}`
- パス別カウンターはデフォルトカウンター（IP のみキー）と独立して管理
- `X-RateLimit-Limit` ヘッダーもパス別 limit を正確に反映

## Test plan
- [ ] `test_path_limits_override_default_limit` など 3 テスト追加 — 全 12 テスト PASS
- [ ] pytest 270 passed, coverage 93.07% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues
- [ ] pip-audit: no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)