### PR TITLE
chore: バージョンを 1.8.1 に更新 (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.1] — 2026-05-20
+
+FT25〜FT28 フィールドトライアル — RequestId ヘルパー・structlog ログレベル・ThrottleMiddleware 改善。
+
+### Added
+- `nene2.middleware.get_request_id()` — FastAPI `Depends` で注入できる request ID ヘルパー関数 (FT25)
+- `setup_logging()` に `log_level: str = "INFO"` パラメータを追加し `AppSettings.log_level` との統合が容易に (FT26)
+- `ThrottleMiddleware` に `path_limits: dict[str, int] | None` パラメータを追加し、パスごとに異なるレート制限を設定可能に (FT28)
+- Field trial reports: `docs/field-trials/2026-05-field-trial-25.md` 〜 `docs/field-trials/2026-05-field-trial-28.md`
+
+### Fixed
+- `ThrottleMiddleware` — ウィンドウ経過後も `_counts` に古いエントリが残り続ける問題を修正（定期クリーンアップを実装）(FT27)
+
+---
+
 ## [1.8.0] — 2026-05-20
 
 FT18〜FT23 フィールドトライアル — ログテスト・Problem Details・ThrottleMiddleware・ドメイン例外・HealthCheck・RequestSizeLimit の各改善。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.0"
+version = "1.8.1"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
FT25〜FT28 の変更を v1.8.1 としてリリース。

### Changes in v1.8.1
- **feat**: `get_request_id()` Depends ヘルパー追加 (FT25)
- **feat**: `setup_logging()` に `log_level` パラメータ追加 (FT26)
- **fix**: ThrottleMiddleware メモリリーク修正 (FT27)
- **feat**: `ThrottleMiddleware` に `path_limits` 追加 (FT28)

## Test plan
- [ ] CI 通過確認
- [ ] タグ付け・PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)