### PR TITLE
docs: AsyncUseCaseProtocol + FastAPI Depends の DI パターンを追加 (#241)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-29.md
+++ b/docs/field-trials/2026-05-field-trial-29.md
@@ -1,0 +1,74 @@
+# FT29: AsyncUseCaseProtocol 実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `AsyncUseCaseProtocol` を使った非同期 UseCase パターンの実運用検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft29-async-usecase/`
+
+---
+
+## 目的
+
+`AsyncUseCaseProtocol` の実装・FastAPI ハンドラーへの統合・並行処理の動作を検証する。
+
+---
+
+## 実施内容
+
+- 外部 API 呼び出しを模した `FetchDataUseCase` を実装
+- `asyncio.gather()` で並行実行を確認
+- Protocol 適合性と isinstance() の既知制限を検証
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_get_item_returns_200 | PASS |
+| test_slow_endpoint_returns_200 | PASS |
+| test_async_use_case_executes_correctly | PASS |
+| test_async_use_case_satisfies_protocol | PASS |
+| test_multiple_async_calls_are_independent | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_isinstance_cannot_distinguish_sync_vs_async_protocol | PASS | 既知（ADR-0010） |
+| test_no_async_usecase_base_class_provided | PASS | 軽微（設計通り） |
+| test_no_generic_di_container_for_async_use_cases | PASS | あり（ドキュメント不備） |
+
+---
+
+## 発見した摩擦点
+
+### FT29-F1: FastAPI Depends を使った AsyncUseCase DI パターンがドキュメント化されていない
+
+**概要**: `AsyncUseCaseProtocol` を FastAPI の依存性注入と統合する標準的なパターンがない。
+ユーザーは毎回自分でパターンを決める必要がある。
+
+```python
+# ユーザーが毎回書く必要があるボイラープレート
+def get_fetch_use_case() -> FetchDataUseCase:
+    return FetchDataUseCase()
+
+@app.get("/items/{item_id}")
+async def get_item(
+    item_id: int,
+    use_case: FetchDataUseCase = Depends(get_fetch_use_case),
+) -> JSONResponse:
+    result = await use_case.execute(FetchDataInput(item_id=item_id))
+    ...
+```
+
+**判断**: how-to ドキュメントに DI パターンを追記する（Issue 化）。
+
+---
+
+## まとめ
+
+`AsyncUseCaseProtocol` の基本機能（実装・FastAPI 統合・並行処理）は問題なく動作する。
+
+摩擦点:
+1. **AsyncUseCase + FastAPI DI パターンがドキュメント化されていない** → Issue 化・how-to に追記
+2. **isinstance() の sync/async 区別不可** → ADR-0010 記載の既知制限、修正不要

--- a/docs/how-to/async-use-case.md
+++ b/docs/how-to/async-use-case.md
@@ -1,0 +1,121 @@
+# How-to: AsyncUseCase と FastAPI の統合
+
+## AsyncUseCaseProtocol の基本実装
+
+`AsyncUseCaseProtocol` は Protocol（構造的部分型）なので継承不要です。
+`async def execute(self, input_: I) -> O` を実装するだけで適合します。
+
+```python
+from dataclasses import dataclass
+from nene2.use_case import AsyncUseCaseProtocol
+
+
+@dataclass(frozen=True, slots=True)
+class FetchUserInput:
+    user_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class FetchUserOutput:
+    user_id: int
+    name: str
+
+
+class FetchUserUseCase:
+    async def execute(self, input_: FetchUserInput) -> FetchUserOutput:
+        # 外部 API 呼び出し・DB アクセスなど非同期処理
+        return FetchUserOutput(user_id=input_.user_id, name="Alice")
+```
+
+---
+
+## FastAPI Depends との統合
+
+ファクトリ関数を `Depends()` に渡すのが標準パターンです。
+
+```python
+from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+
+def get_fetch_user_use_case() -> FetchUserUseCase:
+    return FetchUserUseCase()
+
+
+@app.get("/users/{user_id}")
+async def get_user(
+    user_id: int,
+    use_case: FetchUserUseCase = Depends(get_fetch_user_use_case),
+) -> JSONResponse:
+    result = await use_case.execute(FetchUserInput(user_id=user_id))
+    return JSONResponse({"user_id": result.user_id, "name": result.name})
+```
+
+---
+
+## 外部依存を持つ UseCase の DI
+
+リポジトリや外部クライアントを受け取る UseCase は、依存も Depends で注入します。
+
+```python
+class FetchUserUseCase:
+    def __init__(self, repository: UserRepositoryInterface) -> None:
+        self._repository = repository
+
+    async def execute(self, input_: FetchUserInput) -> FetchUserOutput:
+        user = await self._repository.find_by_id(input_.user_id)
+        return FetchUserOutput(user_id=user.id, name=user.name)
+
+
+def get_user_repository() -> UserRepositoryInterface:
+    return InMemoryUserRepository()
+
+
+def get_fetch_user_use_case(
+    repository: UserRepositoryInterface = Depends(get_user_repository),
+) -> FetchUserUseCase:
+    return FetchUserUseCase(repository)
+```
+
+---
+
+## 並行実行
+
+複数の AsyncUseCase を並行実行するには `asyncio.gather()` を使います。
+
+```python
+import asyncio
+
+
+@app.get("/dashboard")
+async def dashboard(
+    user_id: int,
+    fetch_user: FetchUserUseCase = Depends(get_fetch_user_use_case),
+    fetch_stats: FetchStatsUseCase = Depends(get_fetch_stats_use_case),
+) -> JSONResponse:
+    user, stats = await asyncio.gather(
+        fetch_user.execute(FetchUserInput(user_id=user_id)),
+        fetch_stats.execute(FetchStatsInput(user_id=user_id)),
+    )
+    return JSONResponse({"user": user.name, "stats": stats.count})
+```
+
+---
+
+## isinstance() の注意点
+
+`AsyncUseCaseProtocol` は `@runtime_checkable` ですが、`isinstance()` は
+`execute` 属性の存在のみを確認します（sync/async の区別はしません）。
+
+```python
+# isinstance() は sync UseCase も True を返す（false positive）
+isinstance(sync_use_case, AsyncUseCaseProtocol)  # → True
+
+# 正しい非同期確認方法
+import inspect
+inspect.iscoroutinefunction(use_case.execute)  # → True/False
+```
+
+型安全性は `mypy --strict` の静的解析で保証します。詳細は ADR-0010 を参照してください。


### PR DESCRIPTION
## Summary
- FT29 (AsyncUseCaseProtocol 実運用検証) で発見した摩擦点 FT29-F1 の修正
- `docs/how-to/async-use-case.md` を新規作成
- 基本実装・Depends 統合・外部依存を持つ UseCase・並行実行・isinstance 注意点を網羅

## Test plan
- [ ] docs のみの変更、CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)