### PR TITLE
feat: RequestLoggingMiddleware に extra_context パラメータを追加 (#243)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-30.md
+++ b/docs/field-trials/2026-05-field-trial-30.md
@@ -1,0 +1,66 @@
+# FT30: RequestLoggingMiddleware + structlog バインディング実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `RequestLoggingMiddleware` と structlog contextvars の実運用パターン検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft30-request-logging/`
+
+---
+
+## 目的
+
+`RequestLoggingMiddleware` と structlog の contextvars 統合を実際のアプリで検証し、
+カスタムフィールドの付加方法を確認する。
+
+---
+
+## 実施内容
+
+- `RequestLoggingMiddleware` が自動バインドするコンテキスト（request_id, method, path）を確認
+- 追加のコンテキストフィールドを渡す方法を検証
+- `clear_contextvars()` の挙動確認
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_log_test_endpoint_returns_200 | PASS |
+| test_with_user_context_returns_200 | PASS |
+| test_request_id_is_in_response_header | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_clear_contextvars_wipes_pre_bound_context | PASS | 軽微（設計上の制限） |
+| test_no_way_to_add_extra_fields_to_request_log | PASS | あり |
+
+---
+
+## 発見した摩擦点
+
+### FT30-F1: RequestLoggingMiddleware に extra_context パラメータがない
+
+**概要**: `service_name` や `version` などの静的フィールドを全リクエストログに含めたい場合、
+`RequestLoggingMiddleware` にパラメータとして渡す方法がない。
+
+```python
+# 期待する使い方
+app.add_middleware(
+    RequestLoggingMiddleware,
+    extra_context={"service": "my-api", "version": "1.0.0"},
+)
+```
+
+**期待する解決策**: `extra_context: dict[str, str] | None = None` パラメータを追加し、
+`bind_contextvars()` に追加フィールドとして渡す。
+
+---
+
+## まとめ
+
+`RequestLoggingMiddleware` の基本機能は問題なく動作する。
+
+摩擦点:
+1. **`extra_context` パラメータがない** → Issue 化・修正対象

--- a/src/nene2/middleware/request_logging.py
+++ b/src/nene2/middleware/request_logging.py
@@ -18,11 +18,19 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
     Args:
         exclude_paths: Paths to skip logging for (e.g. ``["/health"]``).
             Useful for high-frequency health-check endpoints where log noise is unwanted.
+        extra_context: Additional key-value pairs bound to every request log entry
+            (e.g. ``{"service": "my-api", "version": "1.0.0"}``).
     """
 
-    def __init__(self, app: object, exclude_paths: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        app: object,
+        exclude_paths: list[str] | None = None,
+        extra_context: dict[str, str] | None = None,
+    ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._exclude_paths = set(exclude_paths or [])
+        self._extra_context: dict[str, str] = extra_context or {}
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         if request.url.path in self._exclude_paths:
@@ -34,6 +42,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             request_id=request_id_var.get(),
             method=request.method,
             path=request.url.path,
+            **self._extra_context,
         )
         logger.info("request.received")
         response = await call_next(request)

--- a/tests/nene2/middleware/test_request_logging.py
+++ b/tests/nene2/middleware/test_request_logging.py
@@ -1,5 +1,6 @@
 """Tests for RequestLoggingMiddleware."""
 
+import structlog
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
@@ -39,6 +40,42 @@ def test_logging_does_not_remove_headers() -> None:
     client = TestClient(_make_app())
     response = client.get("/ping")
     assert "X-Request-Id" in response.headers
+
+
+def test_extra_context_is_bound_to_structlog() -> None:
+    captured: list[dict] = []
+    app = FastAPI()
+    app.add_middleware(
+        RequestLoggingMiddleware,
+        extra_context={"service": "my-api", "version": "1.0"},
+    )
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        captured.append(dict(structlog.contextvars.get_contextvars()))
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    client.get("/ping")
+    assert captured[0]["service"] == "my-api"
+    assert captured[0]["version"] == "1.0"
+
+
+def test_extra_context_default_is_empty() -> None:
+    captured: list[dict] = []
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)  # extra_context なし
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        captured.append(dict(structlog.contextvars.get_contextvars()))
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    client.get("/ping")
+    assert "service" not in captured[0]
 
 
 def test_exclude_paths_passes_requests_through() -> None:


### PR DESCRIPTION
## Summary
- FT30 (RequestLoggingMiddleware 実運用検証) で発見した摩擦点 FT30-F1 の修正
- `extra_context: dict[str, str] | None = None` パラメータを追加
- 全リクエストログに `service_name`, `version` などの静的フィールドを含められる

## Test plan
- [ ] `test_extra_context_is_bound_to_structlog` など 2 テスト追加 — 全 6 テスト PASS
- [ ] pytest 272 passed, coverage 93.07% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues
- [ ] pip-audit: no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)