### PR TITLE
chore: バージョンを 1.8.2 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.2] — 2026-05-20
+
+FT29〜FT30 フィールドトライアル — AsyncUseCase ドキュメント・RequestLoggingMiddleware 改善。
+
+### Added
+- `docs/how-to/async-use-case.md` — `AsyncUseCaseProtocol` + FastAPI `Depends` の DI パターンガイドを追加 (FT29)
+- `RequestLoggingMiddleware` に `extra_context: dict[str, str] | None = None` パラメータを追加し、全ログに静的フィールドを付加できるように (FT30)
+- Field trial reports: `docs/field-trials/2026-05-field-trial-29.md`、`docs/field-trials/2026-05-field-trial-30.md`
+
+---
+
 ## [1.8.1] — 2026-05-20
 
 FT25〜FT28 フィールドトライアル — RequestId ヘルパー・structlog ログレベル・ThrottleMiddleware 改善。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.1"
+version = "1.8.2"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
FT29〜FT30 の変更を v1.8.2 としてリリース。

### Changes in v1.8.2
- **docs**: AsyncUseCase DI パターン how-to ガイド追加 (FT29)
- **feat**: RequestLoggingMiddleware に extra_context パラメータ追加 (FT30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)