### PR TITLE
feat: HealthStatus に http_status_code プロパティを追加 (#246)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-31.md
+++ b/docs/field-trials/2026-05-field-trial-31.md
@@ -1,0 +1,66 @@
+# FT31: DatabaseHealthCheck + ヘルスエンドポイント統合検証
+
+**日付**: 2026-05-20
+**テーマ**: `DatabaseHealthCheck` と `/health` エンドポイントの統合パターン検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft31-health-check/`
+
+---
+
+## 目的
+
+`DatabaseHealthCheck` + `CompositeHealthCheck` を使った `/health` エンドポイントの実装パターンを検証する。
+
+---
+
+## 実施内容
+
+- `DatabaseHealthCheck` + `CompositeHealthCheck` で `/health` を実装
+- DB 接続成功時に 200、失敗時に 503 を返すパターンを確認
+- フレームワークが提供すべき機能の不足を記録
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_health_endpoint_returns_200_when_db_healthy | PASS |
+| test_health_includes_all_checks | PASS |
+| test_ping_returns_200 | PASS |
+| test_health_returns_503_when_db_fails | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_health_endpoint_has_no_built_in_route | PASS | 軽微（how-to 推奨パターン記載で対応） |
+| test_health_status_lacks_http_status_code_mapping | PASS | あり |
+
+---
+
+## 発見した摩擦点
+
+### FT31-F1: HealthStatus が HTTP ステータスコードのマッピングを持たない
+
+**概要**: `/health` エンドポイントを実装するとき、
+`status="ok"` → 200、`status="error"` → 503 のマッピングを毎回手動で書く必要がある。
+
+```python
+# 毎回このボイラープレートが必要
+http_status = 200 if status.is_healthy else 503
+return JSONResponse({"status": status.status}, status_code=http_status)
+
+# 期待する使い方
+return JSONResponse({"status": status.status}, status_code=status.http_status_code)
+```
+
+**期待する解決策**: `HealthStatus` に `http_status_code: int` プロパティを追加する。
+
+---
+
+## まとめ
+
+`DatabaseHealthCheck` + `CompositeHealthCheck` の基本機能は問題なく動作する。
+
+摩擦点:
+1. **`HealthStatus.http_status_code` プロパティがない** → Issue 化・修正対象

--- a/src/nene2/http/health.py
+++ b/src/nene2/http/health.py
@@ -13,6 +13,10 @@ class HealthStatus:
     def is_healthy(self) -> bool:
         return self.status == "ok"
 
+    @property
+    def http_status_code(self) -> int:
+        return 200 if self.is_healthy else 503
+
 
 @runtime_checkable
 class HealthCheckProtocol(Protocol):

--- a/tests/nene2/http/test_health.py
+++ b/tests/nene2/http/test_health.py
@@ -56,3 +56,11 @@ def test_composite_with_empty_checks_returns_ok() -> None:
     result = composite.check()
     assert result.is_healthy is True
     assert result.checks == {}
+
+
+def test_health_status_http_status_code_ok() -> None:
+    assert HealthStatus(status="ok").http_status_code == 200
+
+
+def test_health_status_http_status_code_error() -> None:
+    assert HealthStatus(status="error").http_status_code == 503


### PR DESCRIPTION
## Summary
- FT31 (DatabaseHealthCheck + ヘルスエンドポイント統合) で発見した摩擦点 FT31-F1 の修正
- `HealthStatus.http_status_code` プロパティを追加 — `is_healthy` → 200、それ以外 → 503

## Test plan
- [ ] `test_health_status_http_status_code_ok/error` 2 テスト追加 — 全 9 テスト PASS
- [ ] pytest 274 passed, coverage 93.08% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)