### PR TITLE
feat: SecurityHeadersMiddleware に permissions_policy と hsts パラメータを追加 (#248)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-32.md
+++ b/docs/field-trials/2026-05-field-trial-32.md
@@ -1,0 +1,78 @@
+# FT32: SecurityHeadersMiddleware CSP カスタマイズ実運用検証
+
+**日付**: 2026-05-20
+**テーマ**: `SecurityHeadersMiddleware` のカスタマイズ可能性検証
+**FT アプリ**: `/home/xi/docker/nene2-python-FT/ft32-security-headers/`
+
+---
+
+## 目的
+
+`SecurityHeadersMiddleware` の CSP カスタマイズ機能を実際のアプリで検証し、
+ハードコードされたヘッダーの問題を記録する。
+
+---
+
+## 実施内容
+
+- デフォルトセキュリティヘッダーの確認
+- カスタム CSP の適用確認
+- `extra_no_csp_paths` の動作確認
+- ハードコードされたヘッダーの制限を確認
+
+---
+
+## テスト結果
+
+### test_app.py（正常系・機能確認）
+| テスト | 結果 |
+|---|---|
+| test_default_security_headers_present | PASS |
+| test_default_csp_is_default_src_self | PASS |
+| test_custom_csp_is_applied | PASS |
+| test_docs_path_has_no_csp | PASS |
+| test_extra_no_csp_paths_skip_csp | PASS |
+
+### test_friction.py（摩擦点確認）
+| テスト | 結果 | 摩擦 |
+|---|---|---|
+| test_permissions_policy_is_hardcoded | PASS | あり |
+| test_no_hsts_header | PASS | あり |
+| test_x_frame_options_is_hardcoded_to_deny | PASS | あり（軽微） |
+
+---
+
+## 発見した摩擦点
+
+### FT32-F1: Permissions-Policy がハードコードされている
+
+**概要**: `geolocation=(), microphone=()` が固定値でカスタマイズできない。
+位置情報 API を使うアプリでは `geolocation=(self)` に変更できない。
+
+**期待する解決策**: `permissions_policy: str | None = None` パラメータを追加。
+
+### FT32-F2: HSTS ヘッダーがない
+
+**概要**: production 環境では `Strict-Transport-Security` を設定すべきだが、
+`SecurityHeadersMiddleware` は HSTS を付与しない。
+開発環境では不要なため、オプションとして設定できるべき。
+
+**期待する解決策**: `hsts: str | None = None` パラメータを追加。
+
+### FT32-F3: X-Frame-Options が DENY にハードコード（軽微）
+
+**概要**: iframe 内表示が必要なケースで SAMEORIGIN に変更できない。
+ただし DENY がセキュリティ上より安全なデフォルトであり、一般ユース向け。
+
+**判断**: ニッチなケースのため低優先度。Issue 化はするが即座に修正しない。
+
+---
+
+## まとめ
+
+CSP カスタマイズ機能は問題なく動作する。
+
+摩擦点:
+1. **Permissions-Policy ハードコード** → Issue 化・修正対象
+2. **HSTS ヘッダーなし** → Issue 化・修正対象
+3. **X-Frame-Options ハードコード** → 低優先度 Issue

--- a/src/nene2/middleware/security_headers.py
+++ b/src/nene2/middleware/security_headers.py
@@ -10,12 +10,12 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 _DEFAULT_CSP = "default-src 'self'"
+_DEFAULT_PERMISSIONS_POLICY = "geolocation=(), microphone=()"
 
-_NON_CSP_HEADERS: dict[str, str] = {
+_STATIC_HEADERS: dict[str, str] = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Permissions-Policy": "geolocation=(), microphone=()",
 }
 
 _DEFAULT_NO_CSP_PATHS: frozenset[str] = frozenset({"/docs", "/redoc", "/openapi.json"})
@@ -30,6 +30,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     Args:
         csp: Custom Content-Security-Policy header value.
             Defaults to ``"default-src 'self'"`` when not specified.
+        permissions_policy: Custom Permissions-Policy header value.
+            Defaults to ``"geolocation=(), microphone=()"`` when not specified.
+        hsts: Strict-Transport-Security header value (e.g.
+            ``"max-age=31536000; includeSubDomains"``). Not set by default.
+            Enable only in production environments serving HTTPS.
         extra_no_csp_paths: Additional paths to skip the CSP header for.
             Useful when FastAPI is configured with custom ``docs_url`` / ``redoc_url``.
             The built-in paths ``/docs``, ``/redoc``, and ``/openapi.json`` are always included.
@@ -39,16 +44,25 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         self,
         app: object,
         csp: str | None = None,
+        permissions_policy: str | None = None,
+        hsts: str | None = None,
         extra_no_csp_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._csp = csp if csp is not None else _DEFAULT_CSP
+        self._permissions_policy = (
+            permissions_policy if permissions_policy is not None else _DEFAULT_PERMISSIONS_POLICY
+        )
+        self._hsts = hsts
         self._no_csp_paths = _DEFAULT_NO_CSP_PATHS | frozenset(extra_no_csp_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
-        for header, value in _NON_CSP_HEADERS.items():
+        for header, value in _STATIC_HEADERS.items():
             response.headers[header] = value
+        response.headers["Permissions-Policy"] = self._permissions_policy
+        if self._hsts:
+            response.headers["Strict-Transport-Security"] = self._hsts
         if request.url.path not in self._no_csp_paths:
             response.headers["Content-Security-Policy"] = self._csp
         return response

--- a/tests/nene2/middleware/test_security_headers.py
+++ b/tests/nene2/middleware/test_security_headers.py
@@ -80,6 +80,44 @@ def test_extra_no_csp_paths() -> None:
     assert "Content-Security-Policy" in client.get("/ping").headers
 
 
+def test_custom_permissions_policy() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        permissions_policy="geolocation=(self), microphone=()",
+    )
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    r = client.get("/ping")
+    assert r.headers["Permissions-Policy"] == "geolocation=(self), microphone=()"
+
+
+def test_hsts_header_when_specified() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        hsts="max-age=31536000; includeSubDomains",
+    )
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    r = client.get("/ping")
+    assert r.headers["Strict-Transport-Security"] == "max-age=31536000; includeSubDomains"
+
+
+def test_no_hsts_by_default() -> None:
+    client = TestClient(_make_app())
+    r = client.get("/ping")
+    assert "Strict-Transport-Security" not in r.headers
+
+
 def test_default_no_csp_paths_still_work_with_extra_paths() -> None:
     app = FastAPI()
     app.add_middleware(SecurityHeadersMiddleware, extra_no_csp_paths=["/custom"])


### PR DESCRIPTION
## Summary
- FT32 (SecurityHeadersMiddleware CSP カスタマイズ検証) で発見した摩擦点の修正
- `permissions_policy: str | None = None` を追加 — デフォルト `"geolocation=(), microphone=()"`
- `hsts: str | None = None` を追加 — production 環境での HTTPS 強制

## Test plan
- [ ] `test_custom_permissions_policy`, `test_hsts_header_when_specified`, `test_no_hsts_by_default` 追加 — 全 9 テスト PASS
- [ ] pytest 277 passed, coverage 93.12% (≥80%)
- [ ] mypy: no issues
- [ ] ruff check: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)