### PR TITLE
docs: FT35 混合認証（OR条件）パターンと configure-auth 更新

### DIFF
--- a/docs/field-trials/2026-05-field-trial-35.md
+++ b/docs/field-trials/2026-05-field-trial-35.md
@@ -1,0 +1,90 @@
+# Field Trial 35: 混合認証（Bearer Token OR API Key）実運用検証
+
+**日付**: 2026-05-20
+**バージョン**: v1.8.3 時点
+**テーマ**: `BearerTokenMiddleware` と `ApiKeyAuthMiddleware` の組み合わせパターン、
+および「いずれか一方で可（OR 条件）」認証の実装コストを確認する
+
+---
+
+## 概要
+
+Bearer Token 専用・API Key 専用の各ベースラインを確認した後、
+2 つのミドルウェアをスタックした場合の挙動と、
+OR 条件認証のカスタム実装を比較した。
+
+---
+
+## 実装内容
+
+`/home/xi/docker/nene2-python-FT/ft35-mixed-auth/` に以下を作成:
+
+- **`app.py`** — 4 パターンのアプリ（Bearer のみ・API Key のみ・両方スタック・EitherOr カスタム）
+- **`test_app.py`** — 全パターンの動作検証 (13 件)
+- **`test_friction.py`** — 摩擦点の確認テスト (3 件)
+
+**テスト結果**: 16 件全通過 ✅
+
+---
+
+## 摩擦点
+
+### FP35-1: ミドルウェアを2つスタックすると AND 条件になる
+
+**分類**: 摩擦あり（設計上の制約）
+
+`BearerTokenMiddleware` と `ApiKeyAuthMiddleware` を両方 `add_middleware` すると、
+各ミドルウェアが独立して検証するため「両方必須（AND）」になる。
+Bearer Token のみ・API Key のみの場合どちらも 401。
+
+```python
+# この設定は AND 条件（両方必須）
+app.add_middleware(ApiKeyAuthMiddleware, ...)
+app.add_middleware(BearerTokenMiddleware, ...)
+```
+
+**判断**: Starlette のミドルウェアスタックの仕様通り。
+`configure-auth.md` に明記し、AND と OR の違いを説明する。
+
+---
+
+### FP35-2: OR 条件の認証にはカスタムミドルウェアの実装が必要
+
+**分類**: 摩擦あり（実装コスト発生）
+
+「Bearer または API Key のいずれかで可」を実現するには
+`BaseHTTPMiddleware` を継承してカスタム実装する必要がある。
+フレームワークに汎用 OR ミドルウェアはない。
+
+ただし、`LocalTokenVerifier` / `TokenVerifierProtocol` は再利用可能なため、
+カスタム実装のコードは約 30 行と軽量。
+
+**判断**: OR 条件の仕様はプロジェクトによって多様すぎるため、
+フレームワークが汎用実装を提供するより、パターンをドキュメントで示す方が適切。
+
+**対応**: `docs/how-to/configure-auth.md` に `EitherOrAuthMiddleware` パターンを追記。
+
+---
+
+### FP35-3: TokenVerifierProtocol の再利用性が高い（好印象）
+
+**分類**: 良い設計の確認
+
+`LocalTokenVerifier` はそのままカスタムミドルウェア内で使えるため、
+トークン比較ロジック（`secrets.compare_digest`）を重複実装する必要がない。
+Protocol 分離の設計が効いている。
+
+---
+
+## フレームワーク変更
+
+- `docs/how-to/configure-auth.md` に「AND / OR の違い」と `EitherOrAuthMiddleware` パターンを追記 (FP35-1, FP35-2 対応)
+
+---
+
+## 関連
+
+- `nene2.auth.BearerTokenMiddleware`
+- `nene2.auth.ApiKeyAuthMiddleware`
+- `nene2.auth.LocalTokenVerifier`
+- FT11 (exclude_paths, LocalTokenVerifier.from_env, v1.4.0)

--- a/docs/how-to/configure-auth.md
+++ b/docs/how-to/configure-auth.md
@@ -45,9 +45,56 @@ API_KEYS=["key1","key2"]
 curl -H "X-Api-Key: key1" http://localhost:8080/notes
 ```
 
-## Using both at once
+## Using both at once (AND condition)
 
-When both `BEARER_TOKEN_ENABLED` and `API_KEY_ENABLED` are set, requests must pass both checks. In practice you would choose one or the other.
+When both middlewares are added via `add_middleware`, requests must pass **both** checks (AND condition). A Bearer token alone or an API key alone will both result in 401.
+
+## Either-or authentication (Bearer Token OR API Key)
+
+If you want to accept **either** a Bearer token or an API key — whichever is present — the built-in middlewares cannot express this. Implement a custom middleware that reuses the existing verifiers:
+
+```python
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.auth import LocalTokenVerifier
+from nene2.auth.exceptions import TokenVerificationException
+from nene2.http.problem_details import problem_details_response
+
+class EitherOrAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, *, bearer_tokens: list[str], api_keys: list[str],
+                 exclude_paths: list[str] | None = None) -> None:
+        super().__init__(app)
+        self._bearer = LocalTokenVerifier(bearer_tokens)
+        self._api_key = LocalTokenVerifier(api_keys)
+        self._exclude_paths = set(exclude_paths or [])
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self._exclude_paths:
+            return await call_next(request)
+
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            try:
+                if self._bearer.verify(auth[len("Bearer "):]):
+                    return await call_next(request)
+            except TokenVerificationException:
+                pass
+
+        api_key = request.headers.get("X-Api-Key", "")
+        if api_key:
+            try:
+                if self._api_key.verify(api_key):
+                    return await call_next(request)
+            except TokenVerificationException:
+                pass
+
+        return problem_details_response(
+            "unauthorized", "Unauthorized", 401,
+            "A valid Bearer token or X-Api-Key header is required.",
+        )
+```
 
 ## Disabling auth in tests
 


### PR DESCRIPTION
## Summary

- `docs/how-to/configure-auth.md` に AND / OR 条件の違いを明記し `EitherOrAuthMiddleware` パターンを追記
- `docs/field-trials/2026-05-field-trial-35.md` を追加 — FT35 の実施結果と摩擦点の記録

## 発見した摩擦

2つの認証ミドルウェアをスタックすると AND 条件（両方必須）になる。OR 条件が必要な場合はカスタムミドルウェアが必要だが、LocalTokenVerifier が再利用可能なため実装コストは低い。

## Test plan

- [ ] ドキュメントの内容を確認
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)