### PR TITLE
chore: バージョンを 1.8.4 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.4] — 2026-05-20
+
+FT33〜FT36 フィールドトライアル — バリデーション・DB整合性・混合認証・非同期ヘルスチェック改善。
+
+### Added
+- `AsyncHealthCheckProtocol` — `async def check() -> HealthStatus` の Protocol (FT36)
+- `AsyncCompositeHealthCheck` — 複数の非同期ヘルスチェックを `asyncio.gather` で並列実行して集約するクラス (FT36)
+- `docs/how-to/validation.md` — `ValidationCode(StrEnum)` パターンと複数フィールドバリデーションの how-to ガイドを追加 (FT33)
+- Field trial reports: `docs/field-trials/2026-05-field-trial-33.md` 〜 `docs/field-trials/2026-05-field-trial-36.md`
+
+### Changed
+- `docs/how-to/run-tests.md` — インメモリ SQLite テスト用 `StaticPool` パターンを追記 (FT34)
+- `docs/how-to/configure-auth.md` — AND / OR 条件の違いと `EitherOrAuthMiddleware` パターンを追記 (FT35)
+
+---
+
 ## [1.8.3] — 2026-05-20
 
 FT31〜FT32 フィールドトライアル — HealthCheck・SecurityHeaders 改善。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.3"
+version = "1.8.4"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.3"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

FT33〜FT36 フィールドトライアルの成果をまとめたリリース。

### 新機能
- `AsyncHealthCheckProtocol` + `AsyncCompositeHealthCheck` — 非同期ヘルスチェックサポート

### ドキュメント改善
- `docs/how-to/validation.md` 新規作成（ValidationCode StrEnum パターン）
- `docs/how-to/run-tests.md` — StaticPool パターン追記
- `docs/how-to/configure-auth.md` — OR 認証パターン追記

## Test plan

- [x] `uv run pytest` — 282 passed, coverage 93%
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check` — no issues
- [x] `uv run pip-audit` — no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)