### PR TITLE
feat: RequestSizeLimitMiddleware に path_limits パラメータを追加 (#259)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-39.md
+++ b/docs/field-trials/2026-05-field-trial-39.md
@@ -1,0 +1,95 @@
+# Field Trial 39: RequestSizeLimitMiddleware 実運用検証
+
+**日付**: 2026-05-20
+**バージョン**: v1.8.4 時点
+**テーマ**: `RequestSizeLimitMiddleware` で JSON ボディとバイナリアップロードのサイズを制限するパターンと、パスごとに異なる制限を設定したいユースケースの確認
+
+---
+
+## 概要
+
+小さな `max_bytes` 制限（200 bytes）を設定したアプリで、正常なリクエスト・超過リクエスト・除外パス・境界値を検証した。
+主な発見: パスごとに異なる制限（例: 通常 API は 1 MiB、アップロードエンドポイントは 10 MiB）が設定できない摩擦を発見。`path_limits` パラメータを追加して対応。
+
+---
+
+## 実装内容
+
+`/home/xi/docker/nene2-python-FT/ft39-request-size/` に以下を作成:
+
+- **`app.py`** — `RequestSizeLimitMiddleware(max_bytes=200, exclude_paths=[...])` の動作確認アプリ
+- **`test_app.py`** — 正常・超過・除外パス・境界値の動作確認 (8 件)
+- **`test_friction.py`** — 摩擦点の確認テスト (3 件)
+
+**テスト結果**: 11 件全通過 ✅
+
+---
+
+## 摩擦点
+
+### FP39-1: パスごとに異なる max_bytes を設定できない
+
+**分類**: 摩擦あり → **実装で対応**
+
+`RequestSizeLimitMiddleware` は全体で一つの `max_bytes` のみ設定できる。
+アップロードエンドポイント（例: 10 MiB）と通常 API（例: 1 MiB）で異なる制限を設定したい場合、
+`exclude_paths` でアップロードを除外してハンドラー内で手動チェックするしかなかった。
+
+**対応**: `ThrottleMiddleware.path_limits` と同様のパターンで `path_limits: dict[str, int] | None` を追加 (#259)。
+
+```python
+app.add_middleware(
+    RequestSizeLimitMiddleware,
+    max_bytes=1_048_576,                  # デフォルト: 1 MiB
+    path_limits={
+        "/upload/file": 10_485_760,       # /upload/file: 10 MiB
+        "/api/import": 5_242_880,         # /api/import: 5 MiB
+    },
+)
+```
+
+413 レスポンスの `max_bytes` フィールドはパス固有の制限値を返す。
+
+---
+
+### FP39-2: max_bytes 構造化フィールドが 413 レスポンスに含まれる（FT23 改善の確認）
+
+**分類**: 良い設計の確認
+
+```json
+{
+  "status": 413,
+  "type": ".../payload-too-large",
+  "title": "Payload Too Large",
+  "max_bytes": 200
+}
+```
+
+`max_bytes` フィールドがあることでクライアントがプログラムで制限値を知れる。
+FT23 で追加された改善が実際に役立つことを確認。
+
+---
+
+### FP39-3: Content-Length ヘッダーによる早期拒否が機能する
+
+**分類**: 設計通り（摩擦なし）
+
+Content-Length ヘッダーが `max_bytes` を超える場合、ボディを読む前に 413 を返す。
+メモリ効率が良い設計。
+
+---
+
+## フレームワーク変更
+
+- `RequestSizeLimitMiddleware` に `path_limits: dict[str, int] | None = None` を追加 (FP39-1)
+- テスト 2 件追加
+
+---
+
+## 関連
+
+- `nene2.middleware.RequestSizeLimitMiddleware`
+- FT12 (RequestSizeLimitMiddleware exclude_paths, v1.5.0)
+- FT23 (413 レスポンスに max_bytes 追加, v1.8.0)
+- FT28 (ThrottleMiddleware path_limits, v1.8.1)
+- Issue #259

--- a/src/nene2/middleware/request_size_limit.py
+++ b/src/nene2/middleware/request_size_limit.py
@@ -23,7 +23,18 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
     then reads the actual body to catch chunked-transfer requests that
     omit Content-Length entirely.
 
-    Use ``exclude_paths`` to bypass the size limit for specific endpoints::
+    Use ``path_limits`` to set per-path limits that override the default::
+
+        app.add_middleware(
+            RequestSizeLimitMiddleware,
+            max_bytes=1_048_576,               # default: 1 MiB
+            path_limits={
+                "/upload/file": 10_485_760,    # /upload/file: 10 MiB
+                "/api/import": 5_242_880,      # /api/import: 5 MiB
+            },
+        )
+
+    Use ``exclude_paths`` to bypass the size limit entirely::
 
         app.add_middleware(
             RequestSizeLimitMiddleware,
@@ -37,35 +48,40 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
         app: object,
         *,
         max_bytes: int = _DEFAULT_MAX_BYTES,
+        path_limits: dict[str, int] | None = None,
         exclude_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._max_bytes = max_bytes
+        self._path_limits: dict[str, int] = path_limits or {}
         self._exclude_paths = set(exclude_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in self._exclude_paths:
+        path = request.url.path
+        if path in self._exclude_paths:
             return await call_next(request)
+
+        effective_limit = self._path_limits.get(path, self._max_bytes)
 
         content_length = request.headers.get("Content-Length")
         if content_length is not None:
             try:
-                if int(content_length) > self._max_bytes:
-                    return self._too_large()
+                if int(content_length) > effective_limit:
+                    return self._too_large(effective_limit)
             except ValueError:
                 pass
 
         body = await request.body()
-        if len(body) > self._max_bytes:
-            return self._too_large()
+        if len(body) > effective_limit:
+            return self._too_large(effective_limit)
 
         return await call_next(request)
 
-    def _too_large(self) -> Response:
+    def _too_large(self, limit: int) -> Response:
         return problem_details_response(
             "payload-too-large",
             "Payload Too Large",
             413,
-            _TOO_LARGE.format(limit=self._max_bytes),
-            extra={"max_bytes": self._max_bytes},
+            _TOO_LARGE.format(limit=limit),
+            extra={"max_bytes": limit},
         )

--- a/src/nene2/middleware/request_size_limit.py
+++ b/src/nene2/middleware/request_size_limit.py
@@ -27,10 +27,10 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
 
         app.add_middleware(
             RequestSizeLimitMiddleware,
-            max_bytes=1_048_576,               # default: 1 MiB
+            max_bytes=1_048_576,  # default: 1 MiB
             path_limits={
-                "/upload/file": 10_485_760,    # /upload/file: 10 MiB
-                "/api/import": 5_242_880,      # /api/import: 5 MiB
+                "/upload/file": 10_485_760,  # /upload/file: 10 MiB
+                "/api/import": 5_242_880,  # /api/import: 5 MiB
             },
         )
 

--- a/tests/nene2/middleware/test_request_size_limit.py
+++ b/tests/nene2/middleware/test_request_size_limit.py
@@ -69,6 +69,45 @@ def test_malformed_content_length_is_tolerated() -> None:
     assert response.status_code == 200
 
 
+def test_path_limits_overrides_default_for_specific_paths() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        RequestSizeLimitMiddleware,
+        max_bytes=100,
+        path_limits={"/upload/large": 5000},
+    )
+
+    @app.post("/upload")
+    async def upload() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.post("/upload/large")
+    async def upload_large() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.post("/upload", content=b"x" * 200).status_code == 413
+    assert client.post("/upload/large", content=b"x" * 200).status_code == 200
+
+
+def test_path_limits_413_response_shows_path_limit_not_default() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        RequestSizeLimitMiddleware,
+        max_bytes=1000,
+        path_limits={"/strict": 50},
+    )
+
+    @app.post("/strict")
+    async def strict() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    r = client.post("/strict", content=b"x" * 100)
+    assert r.status_code == 413
+    assert r.json()["max_bytes"] == 50
+
+
 def test_exclude_paths_bypasses_size_limit() -> None:
     app = FastAPI()
     app.add_middleware(


### PR DESCRIPTION
## Summary

- `RequestSizeLimitMiddleware` に `path_limits: dict[str, int] | None = None` を追加
- パスごとに異なるリクエストボディサイズ制限を設定できるように
- `ThrottleMiddleware.path_limits` と同様のパターンで実装
- テスト 2 件追加 (284 passed, coverage 93%)
- FT39 フィールドトライアルレポートを追加

## 使い方

```python
app.add_middleware(
    RequestSizeLimitMiddleware,
    max_bytes=1_048_576,
    path_limits={
        "/upload/file": 10_485_760,
    },
)
```

## Test plan

- [x] `uv run pytest` — 284 passed, coverage 93%
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check` — no issues
- [x] `uv run pip-audit` — no vulnerabilities

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)