### PR TITLE
chore: バージョンを 1.8.6 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.6] — 2026-05-20
+
+FT41〜FT42 フィールドトライアル — structlog テスト統合ドキュメント・configure_problem_details リセット関数。
+
+### Added
+- `nene2.http.reset_problem_details()` — `configure_problem_details()` で設定したグローバル状態をテスト間でリセットするヘルパー関数 (FT42)
+- Field trial reports: `docs/field-trials/2026-05-field-trial-41.md`、`docs/field-trials/2026-05-field-trial-42.md`
+
+### Changed
+- `docs/how-to/run-tests.md` — `configure_for_testing()` + `caplog` による structlog ログキャプチャパターンを追記 (FT41)
+
+---
+
 ## [1.8.5] — 2026-05-20
 
 FT37〜FT40 フィールドトライアル — RequestSizeLimitMiddleware パスごとサイズ制限とドキュメント改善。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.5"
+version = "1.8.6"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.5"
+version = "1.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` バージョンを `1.8.5` → `1.8.6` に更新
- `uv.lock` を更新
- `CHANGELOG.md` に v1.8.6 エントリを追加

## Changes in this release

- `nene2.http.reset_problem_details()` 追加 (FT42 / #264)
- `docs/how-to/run-tests.md` に structlog + caplog パターン追記 (FT41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)