### PR TITLE
feat: request_validation_error_handler を nene2.middleware からエクスポート

### DIFF
--- a/docs/field-trials/2026-05-field-trial-44.md
+++ b/docs/field-trials/2026-05-field-trial-44.md
@@ -1,0 +1,110 @@
+# Field Trial 44: PaginationQueryParser + PaginationResponse 実運用検証
+
+**日付**: 2026-05-20
+**バージョン**: v1.8.6 時点
+**テーマ**: `PaginationQueryParser` を `Annotated[..., Depends()]` 構文で使い `PaginationResponse.to_dict()` でスロット付きデータクラスをシリアライズするパターンの実運用確認
+
+---
+
+## 概要
+
+`PaginationQueryParser` を FastAPI の `Depends()` として注入し、
+`PaginationResponse` + `to_dict()` でスロット付き `dataclass(frozen=True, slots=True)` を
+シリアライズするパターンを実装した。
+`total` フィールドのあり/なし両パターン、および生の dict アイテムを含むケースも確認した。
+
+---
+
+## 実装内容
+
+`/home/xi/docker/nene2-python-FT/ft44-pagination/` に以下を作成:
+
+- **`app.py`** — `PaginationQueryParser` Depends 注入、スロット付きデータクラス `Product`、3 つのエンドポイント（total あり/なし/生 dict）
+- **`test_app.py`** — デフォルト・カスタム・オフセット・total・スロット付きシリアライズ・422 (10 件)
+- **`test_friction.py`** — 摩擦点の確認テスト (4 件)
+
+**テスト結果**: 14 件全通過 ✅
+
+---
+
+## 摩擦点
+
+### FP44-1: OpenAPI スキーマにクエリパラメータが正しく文書化される
+
+**分類**: 摩擦なし（良い設計の確認）
+
+`Annotated[PaginationQueryParser, Depends()]` 構文を使うと、
+`Query(ge=1, le=100, description="Items per page (1–100)")` の情報が
+FastAPI の自動 OpenAPI スキーマ生成に反映される。
+`/openapi.json` の `parameters` に `limit`・`offset` が説明付きで表示される。
+
+**判断**: FT10 で実装した `Depends()` 対応の効果が確認できた。
+
+---
+
+### FP44-2: PaginationResponse.to_dict() は元のアイテムを変更しない
+
+**分類**: 摩擦なし（設計の確認）
+
+`to_dict()` は `dataclasses.asdict()` で新しい dict を生成するため、
+元の `dataclass` インスタンスは変更されない。immutable な `frozen=True` データクラスが
+そのままリポジトリで保持できる。
+
+---
+
+### FP44-3: items が空リストのときも to_dict() が正常動作する
+
+**分類**: 摩擦なし（エッジケース確認）
+
+`items=[]` のとき `to_dict()` は `{"items": [], "limit": 20, "offset": 100, "total": 50}`
+を返す。ページを超えたオフセットでのリクエストが自然に処理される。
+
+---
+
+### FP44-4: Depends() 使用時のバリデーションエラーが Problem Details 形式にならない
+
+**分類**: 摩擦あり（Issues #268 で対応）
+
+`PaginationQueryParser` を `Depends()` として使うと、
+`limit=0` や `limit=101` のバリデーションは FastAPI が実行し、
+エラーは FastAPI のデフォルト Pydantic 形式（`{"detail": [...]}`）になる:
+
+```json
+{"detail": [{"type": "greater_than_equal", ...}]}
+```
+
+一方、nene2 の `ValidationException` は Problem Details 形式:
+
+```json
+{"type": "...", "title": "Validation Failed", "status": 422, "errors": [...]}
+```
+
+この不一致を解消するため、`nene2.middleware.request_validation_error_handler` を
+FastAPI の exception handler として登録することで Problem Details 形式に統一できる:
+
+```python
+from fastapi.exceptions import RequestValidationError
+from nene2.middleware import request_validation_error_handler
+
+app.add_exception_handler(RequestValidationError, request_validation_error_handler)
+```
+
+**対応**: `request_validation_error_handler` は `error_handler.py` に既存実装済みだったが、
+`nene2.middleware` からエクスポートされていなかった (Issue #268)。
+`nene2.middleware.__init__` に追加することで `from nene2.middleware import request_validation_error_handler` が可能になった。
+
+---
+
+## フレームワーク変更
+
+- `nene2.middleware.__init__` に `request_validation_error_handler` を追加エクスポート (#268)
+
+---
+
+## 関連
+
+- `nene2.http.PaginationQueryParser` (FT10, v1.3.0)
+- `nene2.http.PaginationResponse` (FT10, v1.3.0)
+- `nene2.middleware.request_validation_error_handler`
+- FT10 (PaginationQueryParser Depends 対応, v1.3.0)
+- Issue #268 (request_validation_error_handler エクスポート追加)

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -1,7 +1,7 @@
 """NENE2 middleware pipeline."""
 
 from .domain_exception import DomainExceptionHandlerProtocol, SimpleDomainHandler
-from .error_handler import ErrorHandlerMiddleware
+from .error_handler import ErrorHandlerMiddleware, request_validation_error_handler
 from .request_id import RequestIdMiddleware, get_request_id, request_id_var
 from .request_logging import RequestLoggingMiddleware
 from .request_size_limit import RequestSizeLimitMiddleware
@@ -12,6 +12,7 @@ __all__ = [
     "DomainExceptionHandlerProtocol",
     "SimpleDomainHandler",
     "ErrorHandlerMiddleware",
+    "request_validation_error_handler",
     "RequestIdMiddleware",
     "get_request_id",
     "RequestLoggingMiddleware",


### PR DESCRIPTION
## Summary

Closes #268

- `nene2.middleware.__init__` に `request_validation_error_handler` を追加
- `from nene2.middleware import request_validation_error_handler` でアクセス可能に
- FT44 フィールドトライアルレポートを追加

## Background (FP44-4)

`PaginationQueryParser` を `Depends()` で使う場合、FastAPI のバリデーションエラーが
Pydantic 形式 (`{"detail": [...]}`) になり、nene2 の Problem Details 形式と不一致だった。
`request_validation_error_handler` を exception handler として登録することで統一できる:

```python
from fastapi.exceptions import RequestValidationError
from nene2.middleware import request_validation_error_handler

app.add_exception_handler(RequestValidationError, request_validation_error_handler)
```

`request_validation_error_handler` は既に `error_handler.py` に実装済みだったが、
`nene2.middleware` からエクスポートされていなかったため、今回追加した。

## Test plan

- [x] 286 テスト全通過 (93% カバレッジ)
- [x] mypy / ruff check / ruff format --check 全通過
- [x] FT44 アプリ 14 テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)