### PR TITLE
chore: バージョンを 1.8.8 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.8] — 2026-05-20
+
+FT45 フィールドトライアル — SecurityHeadersMiddleware CSP バグ修正。
+
+### Fixed
+- `SecurityHeadersMiddleware` — `csp=""` を渡したとき空の `Content-Security-Policy` ヘッダーが付与される問題を修正。`csp=""` の場合は CSP ヘッダーを付与しないよう変更 (#271) (FT45)
+
+### Added
+- Field trial report: `docs/field-trials/2026-05-field-trial-45.md`
+
+---
+
 ## [1.8.7] — 2026-05-20
 
 FT43〜FT44 フィールドトライアル — ThrottleMiddleware path_limits 確認・PaginationQueryParser バリデーション改善。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.7"
+version = "1.8.8"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.7"
+version = "1.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` バージョンを `1.8.7` → `1.8.8` に更新
- `uv.lock` を更新
- `CHANGELOG.md` に v1.8.8 エントリを追加

## Changes in this release

- `SecurityHeadersMiddleware` の `csp=""` バグ修正 (FT45 / #271)

🤖 Generated with [Claude Code](https://claude.com/claude-code)