### PR TITLE
chore: バージョンを 1.8.9 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.9] — 2026-05-20
+
+FT46〜FT49 フィールドトライアル — ドキュメント改善。
+
+### Added
+- Field trial reports: `docs/field-trials/2026-05-field-trial-46.md` 〜 `docs/field-trials/2026-05-field-trial-49.md`
+
+### Changed
+- `docs/how-to/run-tests.md` — SQLite 外部キー制約 (`PRAGMA foreign_keys=ON`) の注意事項を追記 (FT46)
+
+---
+
 ## [1.8.8] — 2026-05-20
 
 FT45 フィールドトライアル — SecurityHeadersMiddleware CSP バグ修正。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.8"
+version = "1.8.9"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.8"
+version = "1.8.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` バージョンを `1.8.8` → `1.8.9` に更新
- `uv.lock` を更新
- `CHANGELOG.md` に v1.8.9 エントリを追加

## Changes in this release

- FT46〜FT49 フィールドトライアルレポート追加
- `docs/how-to/run-tests.md` に SQLite FK pragma の注意事項追記 (FT46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)