### PR TITLE
fix: pip-audit PYSEC-2025-183 (pyjwt 弱いキー長) を除外 (#280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,6 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
       - name: pip-audit
-        run: uv run pip-audit
+        # PYSEC-2025-183: pyjwt weak-key-length — disputed by supplier, no fix version available.
+        # Transitive via mcp>=1.0. Re-evaluate when pyjwt releases a fix. (#280)
+        run: uv run pip-audit --ignore-vuln PYSEC-2025-183


### PR DESCRIPTION
## Summary
- `pyjwt 2.12.1` の `PYSEC-2025-183` (weak key length) を `pip-audit --ignore-vuln` で除外
- Supplier が争点ありとしており、修正バージョン未リリース
- 依存経路: `mcp>=1.0` → `pyjwt[crypto]` (transitive)

## Reason
PYSEC-2025-183 の説明: "NOTE: this is disputed by the Supplier because the key length is chosen by the application that uses the library"

pyjwt の最新バージョンは 2.12.1 で、これ以上アップグレード不可。Fix Versions も存在しない。

Closes #280

## Test plan
- [x] `uv run pip-audit --ignore-vuln PYSEC-2025-183` → `No known vulnerabilities found, 1 ignored`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)