### PR TITLE
fix: problem_details_response extra reserved fields 保護 (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.11] — 2026-05-20
+
+FT51 フィールドトライアル — SimpleDomainHandler 実運用検証 + problem_details_response バグ修正。
+
+### Fixed
+- `problem_details_response()` — `extra` に RFC 9457 予約済みフィールド (`type`, `title`, `status`, `detail`) が含まれる場合に `ValueError` を raise するよう修正 (#282) (FT51)
+
+### Added
+- Field trial report: `docs/field-trials/2026-05-field-trial-51.md`
+
+---
+
 ## [1.8.10] — 2026-05-20
 
 FT50 フィールドトライアル — ValidationException + ValidationCode(StrEnum) 実運用検証。

--- a/docs/field-trials/2026-05-field-trial-51.md
+++ b/docs/field-trials/2026-05-field-trial-51.md
@@ -1,0 +1,127 @@
+# Field Trial 51: SimpleDomainHandler 実運用検証
+
+**Date**: 2026-05-20
+**Theme**: `SimpleDomainHandler` + `detail_factory` / `extra_factory` の実運用パターン検証
+**Version under test**: v1.8.10
+**FT App**: `/home/xi/docker/nene2-python-FT/ft51-domain-handler/`
+
+---
+
+## 概要
+
+複数のドメイン例外を `SimpleDomainHandler` で Problem Details に変換するパターンを
+記事 API で実運用した。404 / 403 / 409 の 3 種類のエラーを検証。
+
+---
+
+## 実装内容
+
+### ドメイン例外クラス
+
+```python
+class ArticleNotFoundError(Exception):
+    def __init__(self, article_id: int) -> None:
+        self.article_id = article_id
+
+class ArticleAccessDeniedError(Exception):
+    def __init__(self, article_id: int, user_id: str) -> None:
+        self.article_id = article_id
+        self.user_id = user_id
+
+class ArticleTitleConflictError(Exception):
+    def __init__(self, title: str) -> None:
+        self.title = title
+```
+
+### SimpleDomainHandler による登録
+
+```python
+handlers = [
+    SimpleDomainHandler(
+        ArticleNotFoundError,
+        "article-not-found",
+        "Article Not Found",
+        404,
+        detail_factory=lambda exc: str(exc),
+        extra_factory=lambda exc: {"article_id": exc.article_id},
+    ),
+    SimpleDomainHandler(
+        ArticleAccessDeniedError,
+        "article-access-denied",
+        "Access Denied",
+        403,
+        detail_factory=lambda exc: str(exc),
+        extra_factory=lambda exc: {"article_id": exc.article_id, "user_id": exc.user_id},
+    ),
+    SimpleDomainHandler(
+        ArticleTitleConflictError,
+        "article-title-conflict",
+        "Article Title Conflict",
+        409,
+        detail_factory=lambda exc: str(exc),
+        extra_factory=lambda exc: {"article_title": exc.title},  # ← "title" ではなく "article_title"
+    ),
+]
+app.add_middleware(ErrorHandlerMiddleware, domain_handlers=handlers)
+```
+
+---
+
+## テスト結果
+
+6 tests, all passed (after fixing FP51-1).
+
+---
+
+## 摩擦ポイント
+
+### FP51-1: `extra_factory` に `title` キーを返すと Problem Details の `title` が上書きされる
+
+**状況**: `ArticleTitleConflictError` の `extra_factory` で `{"title": exc.title}` を返したところ、
+Problem Details レスポンスの `title` フィールド（`"Article Title Conflict"`）が `exc.title`（`"Dup"`）に
+上書きされた。
+
+```json
+{
+  "type": "...",
+  "title": "Dup",      // ← "Article Title Conflict" のはずが上書きされた
+  "status": 409,
+  "detail": "Article with title 'Dup' already exists"
+}
+```
+
+**原因**: `problem_details_response()` が `body.update(extra)` で `extra` を後から適用するため、
+RFC 9457 の予約済みフィールド (`type`, `title`, `status`, `detail`) を含む `extra` が
+意図せずフィールドを上書きする。
+
+**修正**: `problem_details_response()` が `extra` に予約済みフィールドが含まれている場合に
+`ValueError` を raise するよう修正 (#282)。
+
+```python
+# 修正後のコード
+_RESERVED_FIELDS = frozenset({"type", "title", "status", "detail"})
+if extra:
+    overlap = _RESERVED_FIELDS & extra.keys()
+    if overlap:
+        raise ValueError(f"extra contains reserved Problem Details fields: {sorted(overlap)}")
+    body.update(extra)
+```
+
+**ワークアラウンド（修正前）**: `extra` に予約済みキーと衝突しない名前を使う（例: `"article_title"`）。
+
+---
+
+## フレームワーク変更
+
+### `nene2.http.problem_details_response()` — extra reserved fields 保護 (#282)
+
+`extra` に RFC 9457 予約済みフィールド (`type`, `title`, `status`, `detail`) が含まれる場合に
+`ValueError` を raise するようになった。
+
+---
+
+## 結論
+
+`SimpleDomainHandler` + `detail_factory` / `extra_factory` の組み合わせは実運用で使いやすい。
+ただし `extra_factory` の返り値に RFC 9457 予約済みフィールドと同名のキーを入れると
+サイレントに上書きされる危険があった。`ValueError` による早期検知で問題を防止できる。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.10"
+version = "1.8.11"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/http/problem_details.py
+++ b/src/nene2/http/problem_details.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi.responses import JSONResponse
 
 PROBLEM_DETAILS_BASE_URL = "https://nene2.dev/problems/"
+_RESERVED_FIELDS = frozenset({"type", "title", "status", "detail"})
 
 _configured_base_url: str | None = None
 
@@ -73,6 +74,9 @@ def problem_details_response(
     if detail:
         body["detail"] = detail
     if extra:
+        overlap = _RESERVED_FIELDS & extra.keys()
+        if overlap:
+            raise ValueError(f"extra contains reserved Problem Details fields: {sorted(overlap)}")
         body.update(extra)
 
     return JSONResponse(

--- a/tests/nene2/http/test_problem_details.py
+++ b/tests/nene2/http/test_problem_details.py
@@ -74,3 +74,18 @@ def test_reset_problem_details_is_idempotent() -> None:
     reset_problem_details()
     r = problem_details_response("not-found", "Not Found", 404)
     assert b"nene2.dev/problems/not-found" in r.body
+
+
+def test_extra_with_reserved_field_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="reserved Problem Details fields"):
+        problem_details_response("x", "X", 400, extra={"title": "bad"})
+
+
+def test_extra_with_type_reserved_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="reserved Problem Details fields"):
+        problem_details_response("x", "X", 400, extra={"type": "overridden"})
+
+
+def test_extra_with_status_reserved_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="reserved Problem Details fields"):
+        problem_details_response("x", "X", 400, extra={"status": 500})

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.10"
+version = "1.8.11"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- FT51 で `SimpleDomainHandler` の `extra_factory` から `{"title": exc.title}` を返すと Problem Details の `title` が上書きされる問題を発見
- `problem_details_response()` に `_RESERVED_FIELDS` チェックを追加し、`extra` に予約済みフィールドが含まれる場合に `ValueError` を raise するよう修正

## Changes
- `src/nene2/http/problem_details.py`: `_RESERVED_FIELDS` 定数追加 + overlap チェック
- `tests/nene2/http/test_problem_details.py`: 3 テスト追加 (title/type/status で ValueError)
- `docs/field-trials/2026-05-field-trial-51.md`: FT51 レポート
- version: 1.8.11

## Test plan
- [x] 290 tests passed
- [x] mypy --strict passed
- [x] ruff check passed

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)