### PR TITLE
fix: LocalTokenVerifier.allowed_tokens を set/frozenset に対応 (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.12] — 2026-05-20
+
+FT52 フィールドトライアル — ミドルウェアスタック組み合わせ検証 + LocalTokenVerifier 改善。
+
+### Changed
+- `LocalTokenVerifier.__init__` — `allowed_tokens` の型を `list[str] | set[str] | frozenset[str]` に変更。内部で `frozenset` に変換し `in` 演算が O(1) になった (#284) (FT52)
+
+### Added
+- Field trial report: `docs/field-trials/2026-05-field-trial-52.md`
+
+---
+
 ## [1.8.11] — 2026-05-20
 
 FT51 フィールドトライアル — SimpleDomainHandler 実運用検証 + problem_details_response バグ修正。

--- a/docs/field-trials/2026-05-field-trial-52.md
+++ b/docs/field-trials/2026-05-field-trial-52.md
@@ -1,0 +1,90 @@
+# Field Trial 52: ミドルウェアスタック組み合わせ検証
+
+**Date**: 2026-05-20
+**Theme**: 全ミドルウェアスタック (BearerToken + Throttle + RequestLogging + SecurityHeaders) の組み合わせ実運用
+**Version under test**: v1.8.11
+**FT App**: `/home/xi/docker/nene2-python-FT/ft52-middleware-stack/`
+
+---
+
+## 概要
+
+`ErrorHandlerMiddleware` + `SecurityHeadersMiddleware` + `RequestIdMiddleware` +
+`RequestLoggingMiddleware` + `ThrottleMiddleware` + `BearerTokenMiddleware` を
+全スタックで積み重ねて動作を検証した。
+
+---
+
+## 実装内容
+
+### ミドルウェアスタック
+
+```python
+app.add_middleware(ErrorHandlerMiddleware)
+app.add_middleware(SecurityHeadersMiddleware, csp="default-src 'self'", hsts="max-age=31536000")
+app.add_middleware(RequestIdMiddleware)
+app.add_middleware(RequestLoggingMiddleware, exclude_paths=["/health"], extra_context={"service": "ft52", "env": "test"})
+app.add_middleware(ThrottleMiddleware, limit=5, window=60, exclude_paths=["/health"])
+app.add_middleware(BearerTokenMiddleware, verifier=verifier, exclude_paths=["/health", "/docs", "/openapi.json"])
+```
+
+`/health` は認証・ログ・レート制限をすべてバイパスする設計。
+
+---
+
+## テスト結果
+
+10 tests, all passed (after fixing FP52-1).
+
+| テスト | 結果 |
+|---|---|
+| /health は認証不要 | ✅ |
+| /items は認証必須 | ✅ |
+| 有効トークンで /items アクセス | ✅ |
+| セキュリティヘッダー存在確認 | ✅ |
+| HSTS ヘッダー確認 | ✅ |
+| X-Request-Id ヘッダー確認 | ✅ |
+| X-RateLimit-Limit ヘッダー確認 | ✅ |
+| /health はレート制限なし (10回連続) | ✅ |
+| レート制限超過で 429 | ✅ |
+| 無効トークンで 401 | ✅ |
+
+---
+
+## 摩擦ポイント
+
+### FP52-1: `LocalTokenVerifier` の引数名が直感的でない / `set` 非対応
+
+**状況**: `LocalTokenVerifier(valid_tokens={valid_token})` と書いたが:
+1. 引数名は `valid_tokens` ではなく `allowed_tokens`
+2. `set` を渡すと型エラー（内部が `list[str]` を期待）
+
+**修正**: `allowed_tokens` の型を `list[str] | set[str] | frozenset[str]` に変更し、
+内部で `frozenset` に変換するよう修正 (#284)。
+内部を `frozenset` にすることで `in` 演算の O(n) → O(1) 改善も得られた。
+
+---
+
+## フレームワーク変更
+
+### `LocalTokenVerifier` — `set` / `frozenset` を受け入れ可能に (#284)
+
+```python
+# 修正前
+def __init__(self, allowed_tokens: list[str]) -> None:
+    self._allowed = allowed_tokens
+
+# 修正後
+def __init__(self, allowed_tokens: list[str] | set[str] | frozenset[str]) -> None:
+    self._allowed: frozenset[str] = frozenset(allowed_tokens)
+```
+
+---
+
+## 全スタック動作確認
+
+各ミドルウェアの機能がスタック状態でも正常に動作することを確認:
+- `exclude_paths` の設定が各ミドルウェアで独立して機能する
+- `BearerTokenMiddleware` が `ThrottleMiddleware` より外側（先に評価）
+- `SecurityHeadersMiddleware` のヘッダーが全レスポンスに付与される
+- `RequestIdMiddleware` の `X-Request-Id` が全レスポンスに付与される

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.11"
+version = "1.8.12"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/auth/local_verifier.py
+++ b/src/nene2/auth/local_verifier.py
@@ -11,8 +11,8 @@ import secrets
 class LocalTokenVerifier:
     """Verify tokens against a fixed allowlist using constant-time comparison."""
 
-    def __init__(self, allowed_tokens: list[str]) -> None:
-        self._allowed = allowed_tokens
+    def __init__(self, allowed_tokens: list[str] | set[str] | frozenset[str]) -> None:
+        self._allowed: frozenset[str] = frozenset(allowed_tokens)
 
     @classmethod
     def from_env(cls, env_var: str, *, separator: str = ",") -> "LocalTokenVerifier":

--- a/tests/nene2/auth/test_bearer_token.py
+++ b/tests/nene2/auth/test_bearer_token.py
@@ -113,3 +113,16 @@ def test_exclude_paths_default_is_empty() -> None:
 
     client = TestClient(app)
     assert client.get("/health").status_code == 401
+
+
+def test_local_verifier_accepts_set() -> None:
+    verifier = LocalTokenVerifier({"tok-a", "tok-b"})
+    assert verifier.verify("tok-a") is True
+    assert verifier.verify("tok-b") is True
+    assert verifier.verify("tok-c") is False
+
+
+def test_local_verifier_accepts_frozenset() -> None:
+    verifier = LocalTokenVerifier(frozenset({"tok-x", "tok-y"}))
+    assert verifier.verify("tok-x") is True
+    assert verifier.verify("unknown") is False

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.11"
+version = "1.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- FT52 で `LocalTokenVerifier(valid_tokens={...})` と書いたところ `allowed_tokens` が正式名であり `set` も受け入れないことを発見
- `allowed_tokens` の型を `list[str] | set[str] | frozenset[str]` に拡張
- 内部を `frozenset` で保持することで `in` 演算が O(n) → O(1) に改善

## Changes
- `src/nene2/auth/local_verifier.py`: 型変更 + frozenset 変換
- `tests/nene2/auth/test_bearer_token.py`: set/frozenset テスト追加
- `docs/field-trials/2026-05-field-trial-52.md`: FT52 レポート
- version: 1.8.12

## Test plan
- [x] 292 tests passed
- [x] mypy --strict passed

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)