### PR TITLE
feat: ApiKeyAuthMiddleware に header_name パラメータを追加 (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.13] — 2026-05-20
+
+FT53 フィールドトライアル — ApiKeyAuthMiddleware 実運用検証 + header_name パラメータ追加。
+
+### Added
+- `ApiKeyAuthMiddleware` に `header_name: str = "X-Api-Key"` パラメータを追加 — カスタムヘッダー名 (`X-Service-Token` 等) を指定可能に。エラーメッセージにも `header_name` が反映される (#286) (FT53)
+- Field trial report: `docs/field-trials/2026-05-field-trial-53.md`
+
+---
+
 ## [1.8.12] — 2026-05-20
 
 FT52 フィールドトライアル — ミドルウェアスタック組み合わせ検証 + LocalTokenVerifier 改善。

--- a/docs/field-trials/2026-05-field-trial-53.md
+++ b/docs/field-trials/2026-05-field-trial-53.md
@@ -1,0 +1,81 @@
+# Field Trial 53: ApiKeyAuthMiddleware 実運用検証
+
+**Date**: 2026-05-20
+**Theme**: `ApiKeyAuthMiddleware` の実運用パターン検証
+**Version under test**: v1.8.12
+**FT App**: `/home/xi/docker/nene2-python-FT/ft53-api-key-auth/`
+
+---
+
+## 概要
+
+`ApiKeyAuthMiddleware` + `LocalTokenVerifier(set)` の組み合わせを複数 API キー対応の
+サービスで実運用した。`exclude_paths` と `RequestIdMiddleware` との組み合わせも検証。
+
+---
+
+## 実装内容
+
+```python
+verifier = LocalTokenVerifier({"key-dev-001", "key-dev-002"})
+app.add_middleware(
+    ApiKeyAuthMiddleware,
+    verifier=verifier,
+    exclude_paths=["/health", "/docs", "/openapi.json", "/redoc"],
+)
+```
+
+---
+
+## テスト結果
+
+9 tests, all passed.
+
+---
+
+## 摩擦ポイント
+
+### FP53-1: `ApiKeyAuthMiddleware` のヘッダー名が `X-Api-Key` に固定されている
+
+**状況**: サービスによっては `X-Service-Token` や `X-Internal-Key` など
+異なるヘッダー名を使いたい場合がある。
+
+**修正**: `header_name: str = "X-Api-Key"` パラメータを追加 (#286)。
+
+```python
+app.add_middleware(
+    ApiKeyAuthMiddleware,
+    verifier=verifier,
+    header_name="X-Service-Token",  # カスタムヘッダー名
+)
+```
+
+エラーメッセージにも `header_name` が反映される:
+```
+"A valid X-Service-Token header is required."
+```
+
+**補足**: HTTP ヘッダーは RFC 7230 で大文字小文字無視であるため、
+`X-API-KEY` / `X-Api-Key` などの大文字小文字の違いは問題にならない。
+
+---
+
+## フレームワーク変更
+
+### `ApiKeyAuthMiddleware` — `header_name` パラメータを追加 (#286)
+
+```python
+# デフォルト動作（後方互換）
+ApiKeyAuthMiddleware(verifier=verifier)  # X-Api-Key を使用
+
+# カスタムヘッダー名
+ApiKeyAuthMiddleware(verifier=verifier, header_name="X-Service-Token")
+```
+
+---
+
+## 結論
+
+`ApiKeyAuthMiddleware` は `LocalTokenVerifier(set)` との組み合わせで
+複数 API キーを管理する用途で問題なく動作する。
+`header_name` パラメータの追加で柔軟性が向上した。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.12"
+version = "1.8.13"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/auth/api_key.py
+++ b/src/nene2/auth/api_key.py
@@ -1,6 +1,6 @@
 """API Key authentication middleware.
 
-Validates X-Api-Key header using a TokenVerifierProtocol.
+Validates a configurable header (default: X-Api-Key) using a TokenVerifierProtocol.
 Returns 401 Problem Details when key is absent or invalid.
 """
 
@@ -13,18 +13,18 @@ from nene2.http.problem_details import problem_details_response
 from .exceptions import TokenVerificationException
 from .interfaces import TokenVerifierProtocol
 
-_API_KEY_HEADER = "X-Api-Key"
+_DEFAULT_API_KEY_HEADER = "X-Api-Key"
 
 
 class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
-    """Require a valid X-Api-Key header on every request.
+    """Require a valid API key header on every request.
 
-    Use ``exclude_paths`` to skip authentication for specific paths such as
-    health-check endpoints or API documentation::
+    The header name defaults to ``X-Api-Key`` but can be customised::
 
         app.add_middleware(
             ApiKeyAuthMiddleware,
             verifier=LocalTokenVerifier(api_keys),
+            header_name="X-Service-Token",
             exclude_paths=["/docs", "/openapi.json", "/redoc", "/health"],
         )
     """
@@ -34,16 +34,18 @@ class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
         app: object,
         *,
         verifier: TokenVerifierProtocol,
+        header_name: str = _DEFAULT_API_KEY_HEADER,
         exclude_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._verifier = verifier
+        self._header_name = header_name
         self._exclude_paths = set(exclude_paths or [])
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         if request.url.path in self._exclude_paths:
             return await call_next(request)
-        api_key = request.headers.get(_API_KEY_HEADER, "")
+        api_key = request.headers.get(self._header_name, "")
         try:
             verified = bool(api_key) and self._verifier.verify(api_key)
         except TokenVerificationException:
@@ -53,6 +55,6 @@ class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
                 "unauthorized",
                 "Unauthorized",
                 401,
-                "A valid X-Api-Key header is required.",
+                f"A valid {self._header_name} header is required.",
             )
         return await call_next(request)

--- a/tests/nene2/auth/test_api_key.py
+++ b/tests/nene2/auth/test_api_key.py
@@ -87,3 +87,38 @@ def test_verifier_raises_token_verification_exception_returns_401() -> None:
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/secret", headers={"X-Api-Key": "any-key"})
     assert response.status_code == 401
+
+
+def test_custom_header_name() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=LocalTokenVerifier(["svc-token"]),
+        header_name="X-Service-Token",
+    )
+
+    @app.get("/secret")
+    async def secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/secret", headers={"X-Service-Token": "svc-token"}).status_code == 200
+    assert client.get("/secret", headers={"X-Api-Key": "svc-token"}).status_code == 401
+
+
+def test_custom_header_name_in_error_message() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=LocalTokenVerifier(["tok"]),
+        header_name="X-Internal-Key",
+    )
+
+    @app.get("/secret")
+    async def secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/secret")
+    assert response.status_code == 401
+    assert "X-Internal-Key" in response.json().get("detail", "")

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.12"
+version = "1.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- FT53 で `X-Api-Key` ヘッダー名が固定でカスタマイズできない摩擦を発見
- `header_name: str = "X-Api-Key"` パラメータを追加
- エラーメッセージにも `header_name` が反映される

## Changes
- `src/nene2/auth/api_key.py`: `header_name` パラメータ追加
- `tests/nene2/auth/test_api_key.py`: 2 テスト追加
- `docs/field-trials/2026-05-field-trial-53.md`: FT53 レポート
- version: 1.8.13

## Test plan
- [x] 294 tests passed

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)