### PR TITLE
fix: PROBLEM_DETAILS_BASE_URL を nene2.http からエクスポートするよう修正 (#296)

### DIFF
--- a/src/nene2/http/__init__.py
+++ b/src/nene2/http/__init__.py
@@ -9,6 +9,7 @@ from .health import (
 )
 from .pagination import PaginationQuery, PaginationQueryParser, PaginationResponse
 from .problem_details import (
+    PROBLEM_DETAILS_BASE_URL,
     configure_problem_details,
     problem_details_response,
     reset_problem_details,
@@ -23,6 +24,7 @@ __all__ = [
     "PaginationQuery",
     "PaginationQueryParser",
     "PaginationResponse",
+    "PROBLEM_DETAILS_BASE_URL",
     "configure_problem_details",
     "problem_details_response",
     "reset_problem_details",

--- a/tests/nene2/http/test_problem_details.py
+++ b/tests/nene2/http/test_problem_details.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from nene2.http import configure_problem_details, problem_details_response, reset_problem_details
+from nene2.http import (
+    PROBLEM_DETAILS_BASE_URL,
+    configure_problem_details,
+    problem_details_response,
+    reset_problem_details,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +16,10 @@ def reset_configured_base_url() -> None:
     reset_problem_details()
     yield
     reset_problem_details()
+
+
+def test_problem_details_base_url_constant_is_importable() -> None:
+    assert PROBLEM_DETAILS_BASE_URL == "https://nene2.dev/problems/"
 
 
 def test_problem_details_response_uses_default_base_url() -> None:


### PR DESCRIPTION
## Summary

- `PROBLEM_DETAILS_BASE_URL` 定数を `nene2.http.__init__` のエクスポートに追加
- テストで `from nene2.http import PROBLEM_DETAILS_BASE_URL` が可能になる
- `configure_problem_details()` と同様のインポートパスで利用できるようにする

## Test plan

- [x] `test_problem_details_base_url_constant_is_importable` 追加
- [x] 全テスト通過 (295 passed)
- [x] mypy --strict 通過

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)