### PR TITLE
chore: バージョンを 1.8.16 に更新 (FT63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.16] — 2026-05-20
+
+FT63 フィールドトライアル — configure_problem_details 実運用検証 + PROBLEM_DETAILS_BASE_URL エクスポート修正。
+
+### Fixed
+- `PROBLEM_DETAILS_BASE_URL` 定数を `nene2.http` からエクスポートするよう修正 — テストで `from nene2.http import PROBLEM_DETAILS_BASE_URL` が利用可能になった (#296) (FT63)
+
+### Added
+- Field trial reports: `docs/field-trials/2026-05-field-trial-56.md` 〜 `2026-05-field-trial-63.md` (FT56〜FT63)
+
+---
+
 ## [1.8.15] — 2026-05-20
 
 FT55 フィールドトライアル — parse_db_datetime 実運用検証。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.15"
+version = "1.8.16"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.15"
+version = "1.8.16"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- v1.8.16 リリース
- `PROBLEM_DETAILS_BASE_URL` を `nene2.http` からエクスポートするよう修正 (#296)
- FT56〜FT63 フィールドトライアルレポートを追加

## Test plan

- [x] 全テスト通過 (295 passed)
- [x] mypy --strict 通過
- [x] ruff check & format 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)