### PR TITLE
fix: ValidationError.code にスペースを含む値をエラーにするよう修正 (#300)

### DIFF
--- a/src/nene2/validation/exceptions.py
+++ b/src/nene2/validation/exceptions.py
@@ -9,7 +9,24 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class ValidationError:
-    """A single field-level validation failure."""
+    """A single field-level validation failure.
+
+    Args:
+        field:   The input field that failed (e.g. ``"email"``).
+        message: Human-readable description shown to the user
+                 (e.g. ``"メールアドレスの形式が正しくありません"``).
+        code:    Machine-readable identifier used by API clients to handle
+                 specific errors programmatically (e.g. ``"invalid_email"``).
+                 Must not contain spaces; use ``snake_case``.
+
+    Example::
+
+        ValidationError(
+            field="email",
+            message="メールアドレスの形式が正しくありません",
+            code="invalid_email",
+        )
+    """
 
     field: str
     message: str
@@ -19,6 +36,11 @@ class ValidationError:
         for attr in ("field", "message", "code"):
             if not getattr(self, attr):
                 raise ValueError(f"ValidationError.{attr} must not be empty")
+        if " " in self.code:
+            raise ValueError(
+                f"ValidationError.code must not contain spaces (got {self.code!r}). "
+                "Use snake_case, e.g. 'invalid_email'."
+            )
 
     def to_dict(self) -> dict[str, str]:
         return {"field": self.field, "message": self.message, "code": self.code}
@@ -31,15 +53,36 @@ class ValidationException(Exception):
 
     For a single error, use the convenience method::
 
-        raise ValidationException.single("email", "invalid", "invalid_email")
+        raise ValidationException.single(
+            field="email",
+            message="メールアドレスの形式が正しくありません",
+            code="invalid_email",
+        )
 
     For multiple errors accumulated during validation::
 
-        errors = []
-        if not valid_email:
-            errors.append(ValidationError("email", "invalid", "invalid_email"))
+        errors: list[ValidationError] = []
+        if "@" not in email:
+            errors.append(
+                ValidationError(
+                    field="email",
+                    message="メールアドレスの形式が正しくありません",
+                    code="invalid_email",
+                )
+            )
+        if age < 18:
+            errors.append(
+                ValidationError(
+                    field="age",
+                    message="18歳以上である必要があります",
+                    code="too_young",
+                )
+            )
         if errors:
             raise ValidationException(errors)
+
+    Note: ``message`` is a human-readable string; ``code`` is a machine-readable
+    ``snake_case`` identifier (e.g. ``"invalid_email"``, not ``"Invalid email"``).
     """
 
     def __init__(self, errors: list[ValidationError]) -> None:
@@ -48,5 +91,11 @@ class ValidationException(Exception):
 
     @classmethod
     def single(cls, field: str, message: str, code: str) -> "ValidationException":
-        """Convenience constructor for a single validation error."""
+        """Convenience constructor for a single validation error.
+
+        Args:
+            field:   The input field that failed (e.g. ``"email"``).
+            message: Human-readable description (e.g. ``"Invalid email address"``).
+            code:    Machine-readable ``snake_case`` identifier (e.g. ``"invalid_email"``).
+        """
         return cls([ValidationError(field, message, code)])

--- a/tests/nene2/validation/test_exceptions.py
+++ b/tests/nene2/validation/test_exceptions.py
@@ -44,3 +44,8 @@ def test_validation_exception_single() -> None:
 def test_validation_exception_single_is_validation_exception() -> None:
     exc = ValidationException.single("f", "m", "c")
     assert isinstance(exc, ValidationException)
+
+
+def test_validation_error_code_with_spaces_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="must not contain spaces"):
+        ValidationError(field="email", message="Invalid email", code="invalid email")


### PR DESCRIPTION
## Summary

- `ValidationError.code` にスペースが含まれる場合 `ValueError` を発生させる
- docstring を改善: `message` (人間可読) vs `code` (機械可読 snake_case) の区別を明示
- `ValidationException.single()` のドキュメントも同様に改善

## Background

FT64 で `ValidationError("email", "invalid_email", "...")` のように `message` と `code` を
混同して書いてしまうことが判明。FP 記録: #300

## Test plan

- [x] `test_validation_error_code_with_spaces_raises_value_error` 追加
- [x] 296 tests passed
- [x] mypy --strict 通過

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)