### PR TITLE
docs: SqlAlchemyQueryExecutor に SQLite StaticPool の注意書きを追加 (#305)

### DIFF
--- a/src/nene2/database/sqlalchemy_executor.py
+++ b/src/nene2/database/sqlalchemy_executor.py
@@ -14,7 +14,23 @@ from .interfaces import DatabaseQueryExecutorInterface, DatabaseTransactionManag
 
 
 class SqlAlchemyQueryExecutor(DatabaseQueryExecutorInterface):
-    """Execute queries using SQLAlchemy Core (connection-per-call, no ORM)."""
+    """Execute queries using SQLAlchemy Core (connection-per-call, no ORM).
+
+    .. note:: SQLite in-memory databases
+
+        When using ``sqlite:///:memory:`` in tests, each new connection receives
+        a separate empty database.  To share one in-memory DB across all
+        connections (including ``setup_db`` / schema creation) use
+        ``StaticPool``::
+
+            from sqlalchemy.pool import StaticPool
+
+            engine = create_engine(
+                "sqlite:///:memory:",
+                connect_args={"check_same_thread": False},
+                poolclass=StaticPool,
+            )
+    """
 
     def __init__(self, engine: Engine) -> None:
         self._engine = engine


### PR DESCRIPTION
## Summary

- `SqlAlchemyQueryExecutor` の docstring に SQLite `:memory:` + `StaticPool` の説明を追加
- `sqlite:///:memory:` は接続ごとに別DBが生成されるため StaticPool が必要な旨を記載

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)