### PR TITLE
chore: バージョンを 1.8.18 に更新 (FT67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.18] — 2026-05-20
+
+FT67 フィールドトライアル — SqlAlchemyTransactionManager 実運用検証。
+
+### Changed
+- `SqlAlchemyQueryExecutor` の docstring に SQLite `:memory:` + `StaticPool` の注意書きを追加 (#305) (FT67)
+
+### Added
+- Field trial reports: `docs/field-trials/2026-05-field-trial-65.md` 〜 `2026-05-field-trial-67.md` (FT65〜FT67)
+
+---
+
 ## [1.8.17] — 2026-05-20
 
 FT64 フィールドトライアル — ValidationException 複数エラー実運用検証。

--- a/docs/field-trials/2026-05-field-trial-67.md
+++ b/docs/field-trials/2026-05-field-trial-67.md
@@ -1,0 +1,75 @@
+# FT67: SqlAlchemyTransactionManager 実運用検証
+
+**日付**: 2026-05-20  
+**テーマ**: トランザクション管理 (`SqlAlchemyTransactionManager`) の実運用確認  
+**バージョン**: v1.8.17 → v1.8.18 (ドキュメント追加)  
+**FTディレクトリ**: `/home/xi/docker/nene2-python-FT/ft67-transaction-manager/`
+
+---
+
+## 概要
+
+`nene2.database.SqlAlchemyTransactionManager` を使って口座振替アプリを実装し、
+`transactional()` コールバック API・ロールバック動作・コミット確認を検証した。
+
+---
+
+## 実装内容
+
+- SQLite in-memory DB に `accounts` テーブルを作成
+- `transactional(callback)`: 振替処理を 1 トランザクションで実行
+- 残高不足時は `ValueError` を raise → ロールバック
+- GET `/accounts/{name}` と POST `/transfers` エンドポイント
+
+---
+
+## テスト結果
+
+**7/7 passed** (StaticPool 修正後)
+
+| テスト | 結果 |
+|---|---|
+| `test_get_existing_account` | PASSED |
+| `test_get_nonexistent_account_returns_404` | PASSED |
+| `test_successful_transfer` | PASSED |
+| `test_insufficient_balance_returns_422` | PASSED |
+| `test_transaction_rollback_on_error` | PASSED |
+| `test_transfer_to_nonexistent_account` | PASSED |
+| `test_transactional_commits_on_success` | PASSED |
+
+---
+
+## Friction Points
+
+### FP-1: SQLite `:memory:` と `SqlAlchemyQueryExecutor` の接続分離問題
+
+**発生箇所**: `setup_db()` でテーブル作成後、`executor.fetch_one()` が `no such table: accounts` エラー
+
+**症状**:
+```
+DatabaseConnectionException: (sqlite3.OperationalError) no such table: accounts
+```
+
+**原因**: SQLAlchemy のデフォルトコネクションプールでは `sqlite:///:memory:` への接続ごとに
+新しいインメモリDBが生成される。`setup_db()` と `executor.fetch_one()` が別DBを参照する。
+
+**修正**:
+```python
+from sqlalchemy.pool import StaticPool
+
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+```
+
+`SqlAlchemyQueryExecutor` の docstring に注意書きを追加 (Issue #305, v1.8.18)。
+
+---
+
+## 結論
+
+`SqlAlchemyTransactionManager.transactional()` は実運用で問題なく使用できる。
+コールバック内の例外でロールバックが正しく機能することも確認。
+SQLite in-memory DB 使用時の `StaticPool` 要件はドキュメント化済み。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.17"
+version = "1.8.18"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.17"
+version = "1.8.18"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
v1.8.18 リリース。SqlAlchemyQueryExecutor docstring 改善 (#305)。FT65〜FT67 レポート追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)