### PR TITLE
chore: バージョンを 1.8.19 に更新 (FT68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.19] — 2026-05-20
+
+FT68 フィールドトライアル — SimpleDomainHandler + extra_factory 実運用検証。
+
+### Changed
+- `problem_details_response` の docstring に `extra` がトップレベルにフラットマージされることを明記 (#308) (FT68)
+- `SimpleDomainHandler` の docstring に `extra_factory` のフラットマージ動作を例示 (#308) (FT68)
+
+### Added
+- Field trial report: `docs/field-trials/2026-05-field-trial-68.md`
+
+---
+
 ## [1.8.18] — 2026-05-20
 
 FT67 フィールドトライアル — SqlAlchemyTransactionManager 実運用検証。

--- a/docs/field-trials/2026-05-field-trial-68.md
+++ b/docs/field-trials/2026-05-field-trial-68.md
@@ -1,0 +1,67 @@
+# FT68: SimpleDomainHandler + extra_factory 実運用検証
+
+**日付**: 2026-05-20  
+**テーマ**: ドメイン例外ハンドラー (`SimpleDomainHandler`) + `extra_factory` の実運用確認  
+**バージョン**: v1.8.18 → v1.8.19 (ドキュメント追加)  
+**FTディレクトリ**: `/home/xi/docker/nene2-python-FT/ft68-domain-handler/`
+
+---
+
+## 概要
+
+`nene2.middleware.SimpleDomainHandler` を使って複数のドメイン例外クラスをそれぞれの
+HTTP レスポンスにマッピングし、`extra_factory` による動的フィールドを検証した。
+
+---
+
+## 実装内容
+
+- `ArticleNotFoundError`, `ArticleAccessDeniedError`, `ArticleTitleConflictError`: 独自例外クラス
+- 各例外に `SimpleDomainHandler` + `detail_factory` + `extra_factory` を設定
+- `ErrorHandlerMiddleware(domain_handlers=[...])` に渡して自動ハンドリング
+
+---
+
+## テスト結果
+
+**7/7 passed** (テスト修正後)
+
+| テスト | 結果 |
+|---|---|
+| `test_existing_article_returns_200` | PASSED |
+| `test_not_found_returns_404_with_article_id` | PASSED |
+| `test_access_denied_returns_403` | PASSED |
+| `test_title_conflict_returns_409` | PASSED |
+| `test_detail_factory_populates_detail_field` | PASSED |
+| `test_problem_details_format_compliant` | PASSED |
+| `test_successful_create_returns_201` | PASSED |
+
+---
+
+## Friction Points
+
+### FP-1: `extra_factory` のフィールドがトップレベルにフラットマージされることが不明瞭
+
+**発生箇所**: テストで `data["extra"]["article_id"]` とアクセスして `KeyError: 'extra'`
+
+**症状**:
+```python
+# 期待していた構造
+assert data["extra"]["article_id"] == 999  # → KeyError: 'extra'
+
+# 実際の構造（RFC 9457 extension members = トップレベル）
+assert data["article_id"] == 999  # ← 正しいアクセス方法
+```
+
+**原因**: `extra` という引数名が「ネストされた辞書」を連想させるが、
+実際は RFC 9457 仕様の extension members としてトップレベルにフラットマージされる。
+
+**修正**: `problem_details_response` と `SimpleDomainHandler` の docstring に
+フラットマージである旨とRFC 9457 extension members との関係を明記 (Issue #308, v1.8.19)
+
+---
+
+## 結論
+
+`SimpleDomainHandler` + `extra_factory` は実運用で問題なく使用できる。
+extra フィールドのフラットマージ動作が docstring に明記され、今後は混同を防げる。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.18"
+version = "1.8.19"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.18"
+version = "1.8.19"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
v1.8.19 リリース。extra フラットマージ docstring 改善 (#308)。FT68 レポート追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)