### PR TITLE
feat: ErrorHandlerMiddleware.install() で Pydantic 422 を自動統合

### DIFF
--- a/src/nene2/middleware/error_handler.py
+++ b/src/nene2/middleware/error_handler.py
@@ -11,6 +11,7 @@ from typing import Any
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -32,7 +33,20 @@ logger = logging.getLogger(__name__)
 
 
 class ErrorHandlerMiddleware(BaseHTTPMiddleware):
-    """Catch-all error handler that maps exceptions to Problem Details responses."""
+    """Catch-all error handler that maps exceptions to Problem Details responses.
+
+    **Recommended usage** — use :meth:`install` instead of ``add_middleware`` directly.
+    ``install`` also registers ``request_validation_error_handler`` so that
+    FastAPI's Pydantic validation errors (422) are formatted as nene2 Problem Details::
+
+        ErrorHandlerMiddleware.install(app)
+        # Equivalent to:
+        #   app.add_middleware(ErrorHandlerMiddleware)
+        #   app.add_exception_handler(RequestValidationError, request_validation_error_handler)
+
+    Using ``add_middleware`` directly works, but FastAPI's ``RequestValidationError``
+    will be returned in Pydantic's default format rather than nene2 Problem Details.
+    """
 
     def __init__(
         self,
@@ -44,6 +58,35 @@ class ErrorHandlerMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.debug = debug
         self._domain_handlers: list[DomainExceptionHandlerProtocol] = domain_handlers or []
+
+    @classmethod
+    def install(
+        cls,
+        app: object,
+        *,
+        debug: bool = False,
+        domain_handlers: list[DomainExceptionHandlerProtocol] | None = None,
+    ) -> None:
+        """Add this middleware and register the nene2 validation error handler.
+
+        Registers both ``ErrorHandlerMiddleware`` and ``request_validation_error_handler``
+        so that all 422 responses (Pydantic body validation and ``ValidationException``)
+        are formatted as nene2 Problem Details::
+
+            from nene2.middleware import ErrorHandlerMiddleware
+
+            app = FastAPI()
+            ErrorHandlerMiddleware.install(app)
+
+        Equivalent to::
+
+            app.add_middleware(ErrorHandlerMiddleware, debug=debug, domain_handlers=domain_handlers)
+            app.add_exception_handler(RequestValidationError, request_validation_error_handler)
+        """
+        if not isinstance(app, Starlette):
+            raise TypeError(f"app must be a Starlette/FastAPI instance, got {type(app)!r}")
+        app.add_middleware(cls, debug=debug, domain_handlers=domain_handlers)
+        app.add_exception_handler(RequestValidationError, request_validation_error_handler)
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         try:

--- a/tests/nene2/middleware/test_error_handler.py
+++ b/tests/nene2/middleware/test_error_handler.py
@@ -1,5 +1,6 @@
 """Tests for ErrorHandlerMiddleware."""
 
+import pytest
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -127,3 +128,42 @@ def test_pydantic_validation_error_field_names_are_extracted() -> None:
     assert r.status_code == 422
     fields = [e["field"] for e in r.json()["errors"]]
     assert "rating" in fields
+
+
+def _make_app_via_install() -> FastAPI:
+    class _Body(BaseModel):
+        score: int = Field(ge=0, le=100)
+
+    app = FastAPI()
+    ErrorHandlerMiddleware.install(app)
+
+    @app.post("/scores")
+    async def create_score(body: _Body) -> JSONResponse:
+        return JSONResponse({"score": body.score})
+
+    @app.get("/boom")
+    async def boom() -> JSONResponse:
+        raise RuntimeError("error via install")
+
+    return app
+
+
+def test_install_registers_both_middleware_and_validation_handler() -> None:
+    client = TestClient(_make_app_via_install(), raise_server_exceptions=False)
+    r = client.post("/scores", json={"score": 999})
+    assert r.status_code == 422
+    body = r.json()
+    assert body["type"].endswith("validation-failed")
+    assert "errors" in body
+
+
+def test_install_middleware_still_catches_runtime_errors() -> None:
+    client = TestClient(_make_app_via_install(), raise_server_exceptions=False)
+    r = client.get("/boom")
+    assert r.status_code == 500
+    assert r.json()["type"].endswith("internal-server-error")
+
+
+def test_install_raises_type_error_for_non_starlette_app() -> None:
+    with pytest.raises(TypeError, match="Starlette/FastAPI"):
+        ErrorHandlerMiddleware.install(object())


### PR DESCRIPTION
## Summary

- `ErrorHandlerMiddleware.install(app)` クラスメソッドを追加
- `add_middleware(ErrorHandlerMiddleware)` と `add_exception_handler(RequestValidationError, request_validation_error_handler)` を一度に実行
- Pydantic の 422 バリデーションエラーも nene2 Problem Details 形式に自動統一

## 変更内容

### `src/nene2/middleware/error_handler.py`
- `from starlette.applications import Starlette` を top-level import に追加
- `ErrorHandlerMiddleware.install(app, *, debug, domain_handlers)` クラスメソッドを追加
- docstring に `install()` の推奨使用方法を記載

### `tests/nene2/middleware/test_error_handler.py`
- `test_install_registers_both_middleware_and_validation_handler` を追加
- `test_install_middleware_still_catches_runtime_errors` を追加
- `test_install_raises_type_error_for_non_starlette_app` を追加

## Closes

Closes #315

## Test plan

- [x] 299 passed, coverage 93.25%
- [x] mypy --strict: no issues
- [x] ruff check/format: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)