### PR TITLE
chore: バージョンを 1.8.20 に更新 (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.20] — 2026-05-20
+
+FT72 フィールドトライアル — DatabaseIntegrityException + ErrorHandlerMiddleware.install() 改善。
+
+### Added
+- `ErrorHandlerMiddleware.install(app)` クラスメソッドを追加 (#315) (FT72)
+  — `add_middleware` と `add_exception_handler(RequestValidationError)` を一度に設定し、
+  Pydantic の 422 バリデーションエラーも nene2 Problem Details 形式に自動統一する
+- Field trial reports: `docs/field-trials/2026-05-field-trial-70.md` 〜 `2026-05-field-trial-72.md` (FT70〜FT72)
+
+---
+
 ## [1.8.19] — 2026-05-20
 
 FT68 フィールドトライアル — SimpleDomainHandler + extra_factory 実運用検証。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.19"
+version = "1.8.20"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.19"
+version = "1.8.20"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- バージョンを v1.8.19 → v1.8.20 に更新
- CHANGELOG に v1.8.20 エントリを追加
- `uv.lock` を更新

## 変更内容

- `ErrorHandlerMiddleware.install()` クラスメソッド追加 (#315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)