### PR TITLE
chore: バージョンを 1.8.22 に更新

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.21"
+version = "1.8.22"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.21"
+version = "1.8.22"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` のバージョンを `1.8.21` → `1.8.22` に更新
- `uv.lock` を更新

## 変更内容

- FT76: `run_in_threadpool` を `nene2.use_case` から re-export (#325, #326)

🤖 Generated with [Claude Code](https://claude.com/claude-code)