### PR TITLE
feat: BearerTokenMiddleware / ApiKeyAuthMiddleware に include_paths を追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-77.md
+++ b/docs/field-trials/2026-05-field-trial-77.md
@@ -1,0 +1,179 @@
+# FT77: BearerToken + ApiKey 混在認証
+
+**日付**: 2026-05-20  
+**テーマ**: 同一アプリで認証方式を混在させる — `/admin/*` は JWT Bearer、`/webhook/*` は API Key  
+**バージョン**: v1.8.22  
+**FTディレクトリ**: `/home/xi/docker/nene2-python-FT/ft77-mixed-auth/`
+
+---
+
+## 概要
+
+実運用では「認証方式がルートによって異なる」は非常に一般的なニーズ。
+nene2 の `BearerTokenMiddleware` と `ApiKeyAuthMiddleware` を混在させる方法を検証した。
+ミドルウェアはアプリ全体をカバーするため、`exclude_paths` を使った回避策が必要で、
+ここに大きな摩擦があることが判明した。
+
+---
+
+## 実装したパターン
+
+```
+/admin/*   → BearerTokenMiddleware（JWT Bearer 必須）
+/webhook/* → ApiKeyAuthMiddleware（X-Api-Key 必須）
+/public/*  → 認証不要
+```
+
+### 設定コード
+
+```python
+app.add_middleware(
+    BearerTokenMiddleware,
+    verifier=admin_verifier,
+    exclude_paths=[
+        "/docs", "/openapi.json", "/redoc", "/health",
+        "/public/hello", "/public/status",
+        "/webhook/event", "/webhook/ping",  # ← webhook は除外
+    ],
+)
+
+app.add_middleware(
+    ApiKeyAuthMiddleware,
+    verifier=webhook_verifier,
+    exclude_paths=[
+        "/docs", "/openapi.json", "/redoc", "/health",
+        "/public/hello", "/public/status",
+        "/admin/dashboard", "/admin/users",  # ← admin は除外
+    ],
+)
+```
+
+---
+
+## 発見した問題
+
+### 問題1: exclude_paths の二重管理
+
+認証対象でないパスを **各ミドルウェアに個別に列挙** しなければならない。
+
+- 新しい `/admin/settings` ルートを追加 → `ApiKeyAuthMiddleware` の `exclude_paths` にも追加必要
+- 忘れると: Bearer トークンを持っていても、API Key がないため 401 になる
+- **サイレント障害**: 認証エラーなので「なぜ 401？」と混乱しやすい
+
+### 問題2: exclude_paths はルートではなく完全一致パス
+
+`exclude_paths` はプレフィックスマッチングをサポートしない。
+
+```python
+# ❌ プレフィックスマッチしない
+exclude_paths=["/admin"]  # /admin/dashboard にマッチしない
+
+# ✅ 完全一致のみ
+exclude_paths=["/admin/dashboard", "/admin/users"]  # 各パスを列挙
+```
+
+ルート数が増えると管理が煩雑になる。
+
+### 問題3: per-route 認証デコレーターがない
+
+FastAPI の Depends() パターンでルートごとに認証を指定することが nene2 では直接できない。
+
+```python
+# FastAPI 標準 (nene2 提供なし)
+from fastapi.security import HTTPBearer
+security = HTTPBearer()
+
+@app.get("/admin/dashboard")
+def admin(token = Depends(security)):
+    ...
+```
+
+nene2 でこれをやるには生の FastAPI `Depends()` を使う必要があり、
+nene2 の `TokenVerifierProtocol` との統合方法が不明瞭。
+
+### 問題4: 「どちらかで認証」が実現できない
+
+Bearer でも API Key でも OK という「OR 認証」がミドルウェア方式では実現困難。
+
+```
+# 現状では:
+BearerMiddleware: 対象パスはBearer必須
+ApiKeyMiddleware: 対象パスはApiKey必須
+
+# 実現できない:
+"Bearer OR ApiKey どちらかがあれば OK"
+```
+
+---
+
+## テスト結果（全17件パス）
+
+```
+test_public_hello_no_auth               PASSED  # 公開エンドポイント
+test_public_status_no_auth              PASSED
+test_health_no_auth                     PASSED
+test_admin_with_valid_bearer            PASSED  # 正常認証
+test_admin_without_auth_returns_401     PASSED
+test_admin_with_invalid_bearer_returns_401  PASSED
+test_admin_with_api_key_instead_of_bearer_returns_401  PASSED  # 認証方式が違う
+test_admin_users_with_valid_bearer      PASSED
+test_webhook_with_valid_api_key         PASSED
+test_webhook_without_auth_returns_401   PASSED
+test_webhook_with_invalid_api_key_returns_401  PASSED
+test_webhook_with_bearer_instead_of_api_key_returns_401  PASSED
+test_admin_with_both_headers_bearer_wins  PASSED  # 両方送ると適切に処理
+test_webhook_with_both_headers_apikey_wins  PASSED
+test_friction_new_admin_route_needs_exclude_update  PASSED  # 摩擦の記録
+test_friction_exclude_paths_is_per_middleware  PASSED
+test_nene2_has_no_per_route_auth_decorator  PASSED  # per-route 機能なし確認
+```
+
+---
+
+## 摩擦ポイント一覧
+
+| ID | 内容 | 深刻度 |
+|---|---|---|
+| F77-1 | exclude_paths の二重管理 — 新ルートを追加するたびに各ミドルウェアを更新 | 高 |
+| F77-2 | exclude_paths がプレフィックスマッチをサポートしない（完全一致のみ）| 中 |
+| F77-3 | per-route 認証デコレーターがない — Depends() との統合方法が不明 | 中 |
+| F77-4 | Bearer OR ApiKey の OR 認証が実現できない | 中 |
+
+---
+
+## 使用感（主観評価）
+
+### 直感性 ★★☆☆☆
+
+「ミドルウェアは全体をカバーする」という原則は理解できる。
+しかし「特定のルートだけ認証したい」という非常に一般的なニーズに、
+`exclude_paths` という「否定のリスト」で対応するのは直感に反する。
+
+Express の `passport.authenticate()` や Spring Security の `requestMatchers()` は
+「守りたいパスを指定」するモデル。nene2 は「除外するパスを指定」という逆のモデルで混乱しやすい。
+
+### 実害の深刻さ ★★★★☆
+
+新しいルートを追加したとき、`exclude_paths` の更新を忘れると **サイレントな認証エラー** が発生する。
+本番でユーザーが急に 401 になり、コードを読んでも一見問題がないように見える。
+ミドルウェアの設定を疑わないと根本原因に辿り着けない。
+
+### 修正のしやすさ ★★★☆☆
+
+根本解決は「プレフィックスマッチ対応」または「per-route auth」の提供。
+プレフィックスマッチは小さな変更で実現できる。
+per-route auth の提供は FastAPI Depends() との統合が必要で中程度の工数。
+
+### 総合コメント
+
+「守りたいパスのプレフィックスを指定する」モデルへの転換が最も効果的。
+`include_paths: list[str] | None` または `path_prefix: str` パラメーターを追加するだけで、
+「`/admin` 以下は全部 Bearer 必須」と書けるようになり、UX が大幅に改善する。
+
+---
+
+## 推奨アクション
+
+1. **Issue**: `BearerTokenMiddleware` / `ApiKeyAuthMiddleware` に `include_paths` または `path_prefixes` パラメーターを追加
+2. **Issue**: `exclude_paths` にプレフィックスマッチ（`/admin/*` 形式）をサポート
+3. **将来**: `nene2.auth` に FastAPI `Depends()` 統合ヘルパーを提供

--- a/src/nene2/auth/api_key.py
+++ b/src/nene2/auth/api_key.py
@@ -17,10 +17,30 @@ _DEFAULT_API_KEY_HEADER = "X-Api-Key"
 
 
 class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
-    """Require a valid API key header on every request.
+    """Require a valid API key header on matching requests.
 
-    The header name defaults to ``X-Api-Key`` but can be customised::
+    The header name defaults to ``X-Api-Key`` but can be customised.
 
+    **Path filtering** — two complementary options (mutually exclusive):
+
+    - ``include_paths``: only protect paths whose prefix matches one of these values.
+      All other paths pass through without authentication.
+      Ideal for protecting a specific sub-tree (e.g. ``["/webhook"]``).
+    - ``exclude_paths``: protect every path **except** these exact paths.
+      Ideal for skipping docs / health endpoints.
+
+    When both are provided, ``include_paths`` takes precedence.
+
+    Examples::
+
+        # Protect only /webhook/* routes (prefix match)
+        app.add_middleware(
+            ApiKeyAuthMiddleware,
+            verifier=LocalTokenVerifier(api_keys),
+            include_paths=["/webhook"],
+        )
+
+        # Protect everything except docs/health (exact match)
         app.add_middleware(
             ApiKeyAuthMiddleware,
             verifier=LocalTokenVerifier(api_keys),
@@ -36,14 +56,21 @@ class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
         verifier: TokenVerifierProtocol,
         header_name: str = _DEFAULT_API_KEY_HEADER,
         exclude_paths: list[str] | None = None,
+        include_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._verifier = verifier
         self._header_name = header_name
         self._exclude_paths = set(exclude_paths or [])
+        self._include_paths = list(include_paths or [])
+
+    def _should_authenticate(self, path: str) -> bool:
+        if self._include_paths:
+            return any(path.startswith(prefix) for prefix in self._include_paths)
+        return path not in self._exclude_paths
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in self._exclude_paths:
+        if not self._should_authenticate(request.url.path):
             return await call_next(request)
         api_key = request.headers.get(self._header_name, "")
         try:

--- a/src/nene2/auth/bearer_token.py
+++ b/src/nene2/auth/bearer_token.py
@@ -17,11 +17,28 @@ _WWW_AUTH = 'Bearer realm="api"'
 
 
 class BearerTokenMiddleware(BaseHTTPMiddleware):
-    """Require a valid Bearer token on every request.
+    """Require a valid Bearer token on matching requests.
 
-    Use ``exclude_paths`` to skip authentication for specific paths such as
-    health-check endpoints or API documentation::
+    **Path filtering** — two complementary options (mutually exclusive):
 
+    - ``include_paths``: only protect paths whose prefix matches one of these values.
+      All other paths pass through without authentication.
+      Ideal for protecting a specific sub-tree (e.g. ``["/admin"]``).
+    - ``exclude_paths``: protect every path **except** these exact paths.
+      Ideal for skipping docs / health endpoints.
+
+    When both are provided, ``include_paths`` takes precedence.
+
+    Examples::
+
+        # Protect only /admin/* routes (prefix match)
+        app.add_middleware(
+            BearerTokenMiddleware,
+            verifier=LocalTokenVerifier(tokens),
+            include_paths=["/admin"],
+        )
+
+        # Protect everything except docs/health (exact match)
         app.add_middleware(
             BearerTokenMiddleware,
             verifier=LocalTokenVerifier(tokens),
@@ -35,13 +52,20 @@ class BearerTokenMiddleware(BaseHTTPMiddleware):
         *,
         verifier: TokenVerifierProtocol,
         exclude_paths: list[str] | None = None,
+        include_paths: list[str] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._verifier = verifier
         self._exclude_paths = set(exclude_paths or [])
+        self._include_paths = list(include_paths or [])
+
+    def _should_authenticate(self, path: str) -> bool:
+        if self._include_paths:
+            return any(path.startswith(prefix) for prefix in self._include_paths)
+        return path not in self._exclude_paths
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in self._exclude_paths:
+        if not self._should_authenticate(request.url.path):
             return await call_next(request)
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):

--- a/tests/nene2/auth/test_api_key.py
+++ b/tests/nene2/auth/test_api_key.py
@@ -122,3 +122,72 @@ def test_custom_header_name_in_error_message() -> None:
     response = client.get("/secret")
     assert response.status_code == 401
     assert "X-Internal-Key" in response.json().get("detail", "")
+
+
+# ---------------------------------------------------------------------------
+# include_paths tests
+# ---------------------------------------------------------------------------
+def test_include_paths_protects_matching_prefix() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=LocalTokenVerifier(["key"]),
+        include_paths=["/webhook"],
+    )
+
+    @app.get("/webhook/event")
+    async def webhook_event() -> JSONResponse:
+        return JSONResponse({"received": True})
+
+    @app.get("/public/hello")
+    async def public_hello() -> JSONResponse:
+        return JSONResponse({"hello": True})
+
+    client = TestClient(app)
+    assert client.get("/webhook/event").status_code == 401
+    assert client.get("/webhook/event", headers={"X-Api-Key": "key"}).status_code == 200
+    assert client.get("/public/hello").status_code == 200
+
+
+def test_include_paths_multiple_prefixes() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=LocalTokenVerifier(["key"]),
+        include_paths=["/webhook", "/internal"],
+    )
+
+    @app.get("/webhook/x")
+    async def webhook_x() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/internal/y")
+    async def internal_y() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/public/z")
+    async def public_z() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.get("/webhook/x").status_code == 401
+    assert client.get("/internal/y").status_code == 401
+    assert client.get("/public/z").status_code == 200
+
+
+def test_include_paths_takes_precedence_over_exclude_paths() -> None:
+    """両方指定されたときは include_paths が優先される。"""
+    app = FastAPI()
+    app.add_middleware(
+        ApiKeyAuthMiddleware,
+        verifier=LocalTokenVerifier(["key"]),
+        include_paths=["/webhook"],
+        exclude_paths=["/webhook/open"],  # include_paths があるので無視される
+    )
+
+    @app.get("/webhook/open")
+    async def webhook_open() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.get("/webhook/open").status_code == 401

--- a/tests/nene2/auth/test_bearer_token.py
+++ b/tests/nene2/auth/test_bearer_token.py
@@ -126,3 +126,84 @@ def test_local_verifier_accepts_frozenset() -> None:
     verifier = LocalTokenVerifier(frozenset({"tok-x", "tok-y"}))
     assert verifier.verify("tok-x") is True
     assert verifier.verify("unknown") is False
+
+
+# ---------------------------------------------------------------------------
+# include_paths tests
+# ---------------------------------------------------------------------------
+def _make_app_with_include_paths(tokens: list[str], include_paths: list[str]) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        BearerTokenMiddleware,
+        verifier=LocalTokenVerifier(tokens),
+        include_paths=include_paths,
+    )
+
+    @app.get("/admin/dashboard")
+    async def admin_dashboard() -> JSONResponse:
+        return JSONResponse({"admin": True})
+
+    @app.get("/public/hello")
+    async def public_hello() -> JSONResponse:
+        return JSONResponse({"hello": True})
+
+    return app
+
+
+def test_include_paths_protects_matching_prefix() -> None:
+    client = TestClient(_make_app_with_include_paths(["tok"], ["/admin"]))
+    assert client.get("/admin/dashboard").status_code == 401
+    assert (
+        client.get("/admin/dashboard", headers={"Authorization": "Bearer tok"}).status_code == 200
+    )
+
+
+def test_include_paths_skips_non_matching_prefix() -> None:
+    """include_paths にないパスは認証なしで通過する。"""
+    client = TestClient(_make_app_with_include_paths(["tok"], ["/admin"]))
+    assert client.get("/public/hello").status_code == 200
+
+
+def test_include_paths_multiple_prefixes() -> None:
+    app = FastAPI()
+    app.add_middleware(
+        BearerTokenMiddleware,
+        verifier=LocalTokenVerifier(["tok"]),
+        include_paths=["/admin", "/private"],
+    )
+
+    @app.get("/admin/x")
+    async def admin_x() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/private/y")
+    async def private_y() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/public/z")
+    async def public_z() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.get("/admin/x").status_code == 401
+    assert client.get("/private/y").status_code == 401
+    assert client.get("/public/z").status_code == 200
+
+
+def test_include_paths_takes_precedence_over_exclude_paths() -> None:
+    """両方指定されたときは include_paths が優先される。"""
+    app = FastAPI()
+    app.add_middleware(
+        BearerTokenMiddleware,
+        verifier=LocalTokenVerifier(["tok"]),
+        include_paths=["/admin"],
+        exclude_paths=["/admin/open"],  # include_paths があるので無視される
+    )
+
+    @app.get("/admin/open")
+    async def admin_open() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    # include_paths=["/admin"] が優先 → /admin/open も保護される
+    assert client.get("/admin/open").status_code == 401


### PR DESCRIPTION
## Summary

- `BearerTokenMiddleware` と `ApiKeyAuthMiddleware` に `include_paths` パラメーターを追加
- プレフィックスマッチで「守りたいパス」を直接指定できるようになった
- 混在認証（`/admin/*` は Bearer、`/webhook/*` は API Key）が `exclude_paths` 二重管理なしに実現可能

## Before / After

**Before**: `/admin/*` と `/webhook/*` で認証方式を分けるには両ミドルウェアに exclude_paths を列挙

```python
app.add_middleware(BearerTokenMiddleware, verifier=...,
    exclude_paths=["/public/...", "/webhook/event", "/webhook/ping", ...])  # 全部列挙
app.add_middleware(ApiKeyAuthMiddleware, verifier=...,
    exclude_paths=["/public/...", "/admin/dashboard", "/admin/users", ...])  # 全部列挙
```

**After**: `include_paths` でプレフィックス指定

```python
app.add_middleware(BearerTokenMiddleware, verifier=..., include_paths=["/admin"])
app.add_middleware(ApiKeyAuthMiddleware, verifier=..., include_paths=["/webhook"])
```

## 動作

- `include_paths` 指定時: マッチするプレフィックスのパスのみ認証チェック
- `include_paths` と `exclude_paths` 両方指定: `include_paths` が優先
- 後方互換性: 両方未指定の場合は従来通り全体をカバー

## Test plan

- [x] `test_include_paths_protects_matching_prefix` — プレフィックスにマッチするパスが保護される
- [x] `test_include_paths_skips_non_matching_prefix` — マッチしないパスは通過する
- [x] `test_include_paths_multiple_prefixes` — 複数プレフィックスが動作
- [x] `test_include_paths_takes_precedence_over_exclude_paths` — include_paths 優先

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)