### PR TITLE
chore: バージョンを 1.8.23 に更新

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.22"
+version = "1.8.23"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.22"
+version = "1.8.23"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` のバージョンを `1.8.22` → `1.8.23` に更新
- FT77: `include_paths` サポート追加 (#329, #331)

🤖 Generated with [Claude Code](https://claude.com/claude-code)