### PR TITLE
feat: RequestLoggingMiddleware に context_extractor コールバックを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-79.md
+++ b/docs/field-trials/2026-05-field-trial-79.md
@@ -1,0 +1,186 @@
+# FT79: RequestLoggingMiddleware と構造化ログ
+
+**日付**: 2026-05-20  
+**テーマ**: リクエストログに何が含まれるか — 機密情報漏洩リスクとデバッグ適性の確認  
+**バージョン**: v1.8.24  
+**FTディレクトリ**: `/home/xi/docker/nene2-python-FT/ft79-request-logging/`
+
+---
+
+## 概要
+
+`RequestLoggingMiddleware` と `structlog` の組み合わせを検証した。
+基本機能は期待通り動作し、セキュリティ設計（ボディをログしない）も適切。
+一方で、リクエストボディの選択的ログ記録やリクエストごとの動的コンテキスト追加といった
+デバッグ用途での柔軟性の欠如が摩擦点として判明した。
+
+---
+
+## ログ出力の内容（確認済み）
+
+### request.received
+
+```json
+{
+  "event": "request.received",
+  "level": "info",
+  "logger": "nene2.middleware.request_logging",
+  "method": "GET",
+  "path": "/api/users",
+  "request_id": "abc-123",
+  "service": "ft79-app",
+  "version": "1.0.0"
+}
+```
+
+### request.completed
+
+```json
+{
+  "event": "request.completed",
+  "level": "info",
+  "logger": "nene2.middleware.request_logging",
+  "method": "GET",
+  "path": "/api/users",
+  "status_code": 200,
+  "duration_ms": 1.4,
+  "request_id": "abc-123",
+  "service": "ft79-app",
+  "version": "1.0.0"
+}
+```
+
+---
+
+## セキュリティ設計（良い点）
+
+### リクエストボディをログしない ✅
+
+```python
+# POST /api/users {"name": "alice", "password": "super-secret-pw"}
+# → ログには password が含まれない
+```
+
+nene2 は `url.path` のみをログし、ボディも Cookie も Authorization ヘッダーも記録しない。
+Django の `request_finished` シグナルや Flask-Login のデフォルト設定で
+機密情報がログに漏洩するケースと対照的に、nene2 はデフォルトで安全。
+
+### クエリパラメーターをログしない ✅
+
+```
+GET /api/users?secret_token=hidden
+```
+
+`url.path` は `/api/users` のみを返すため、クエリパラメーターはログに含まれない。
+URLにAPIキーを含める（推奨されないが）パターンでも機密情報が漏洩しない。
+
+---
+
+## 発見した問題
+
+### 問題1: extra_context が静的のみ — リクエストごとの動的コンテキストが追加できない
+
+```python
+# 現状: アプリ起動時の静的な値のみ
+app.add_middleware(
+    RequestLoggingMiddleware,
+    extra_context={"service": "my-api", "version": "1.0.0"},
+)
+```
+
+```python
+# 欲しいが実現できない: リクエストごとの動的な値
+# → JWT から取り出した user_id をログに含めたい
+# → テナントIDをログに含めたい
+app.add_middleware(
+    RequestLoggingMiddleware,
+    context_extractor=lambda request: {"user_id": get_user_id(request)},  # 非対応
+)
+```
+
+`structlog.contextvars.bind_contextvars()` を直接使えば可能だが、
+その場合はミドルウェアを自作する必要がある。
+
+### 問題2: デバッグ時のリクエストボディログ方法が不明
+
+本番では不要だが、開発時にリクエストボディをログしたいケースがある。
+現状では nene2 でこれを行う方法がなく、
+カスタムミドルウェアを追加するか `add_route_logging` のようなデコレーターを自作する必要がある。
+
+### 問題3: configure_for_testing() を使わないと caplog でキャプチャできない
+
+```python
+# conftest.py に必須
+from nene2.log import configure_for_testing
+configure_for_testing()
+```
+
+この設定を忘れると `caplog` で nene2 のログがキャプチャできず、
+「テストしてるのにログが出ない」という混乱を招く。
+ドキュメントへの明示が必要。
+
+---
+
+## テスト結果（全14件パス）
+
+```
+test_request_received_logged            PASSED
+test_request_completed_logged           PASSED
+test_method_and_path_in_log             PASSED
+test_status_code_in_completed_log       PASSED
+test_duration_in_completed_log          PASSED
+test_extra_context_in_log               PASSED
+test_health_not_logged                  PASSED
+test_request_body_not_in_log            PASSED
+test_request_query_params_in_nene2_log  PASSED  # nene2はクエリを含まない ✅
+test_error_request_still_logged         PASSED
+test_error_request_has_status_500       PASSED
+test_friction_no_request_body_logging_api  PASSED
+test_friction_no_response_body_logging  PASSED
+test_friction_no_user_id_in_log_without_custom_context  PASSED
+```
+
+---
+
+## 摩擦ポイント一覧
+
+| ID | 内容 | 深刻度 |
+|---|---|---|
+| F79-1 | extra_context が静的のみ — リクエストごとの動的コンテキスト（user_id等）が追加できない | 中 |
+| F79-2 | デバッグ用のリクエストボディログ方法がない | 低 |
+| F79-3 | configure_for_testing() 未設定だと caplog でログがキャプチャできない | 中 |
+
+---
+
+## 使用感（主観評価）
+
+### 直感性 ★★★★★
+
+`setup_middlewares(app)` で自動的にリクエストログが有効になるのは非常に快適。
+`extra_context` で追加フィールドを注入できる設計もわかりやすい。
+`exclude_paths` でヘルスチェックを除外できるのも実務的。
+
+### 実害の深刻さ ★★☆☆☆
+
+機密情報をログしないデフォルト設計は本番環境で非常に重要で、これは大きな強み。
+`configure_for_testing()` の存在を知らないと pytest で詰まるが、
+ドキュメントに追記すれば解決する軽い問題。
+
+### 修正のしやすさ ★★★★☆
+
+動的コンテキストの追加は `context_extractor` コールバックを追加すれば実現できる。
+実装は `dispatch()` 内で `context_extractor(request)` を呼んで結果を `bind_contextvars()` に渡すだけ。
+
+### 総合コメント
+
+RequestLoggingMiddleware は実用的でセキュリティ設計も適切。
+`configure_for_testing()` のドキュメント強化と、
+`context_extractor` パラメーターの追加でさらに実用性が高まる。
+全体的に「使っていて気持ちいい」ミドルウェア。
+
+---
+
+## 推奨アクション
+
+1. **Issue**: `RequestLoggingMiddleware` に `context_extractor` コールバックパラメーターを追加
+2. **Issue**: `configure_for_testing()` の使い方を README のテストセクションに追記

--- a/src/nene2/middleware/request_logging.py
+++ b/src/nene2/middleware/request_logging.py
@@ -1,6 +1,8 @@
 """Request logging middleware using structlog."""
 
+import contextlib
 import time
+from collections.abc import Callable
 
 import structlog
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -20,6 +22,21 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             Useful for high-frequency health-check endpoints where log noise is unwanted.
         extra_context: Additional key-value pairs bound to every request log entry
             (e.g. ``{"service": "my-api", "version": "1.0.0"}``).
+        context_extractor: Optional callable ``(request) -> dict[str, str]`` that
+            returns per-request dynamic context (e.g. user ID from JWT, tenant ID).
+            The returned dict is merged into the log context for each request::
+
+                def get_log_context(request: Request) -> dict[str, str]:
+                    return {"user_id": request.headers.get("X-User-Id", "anonymous")}
+
+
+                app.add_middleware(
+                    RequestLoggingMiddleware,
+                    context_extractor=get_log_context,
+                )
+
+            If the extractor raises an exception, it is silently skipped so that
+            logging failures never break request handling.
     """
 
     def __init__(
@@ -27,10 +44,12 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         app: object,
         exclude_paths: list[str] | None = None,
         extra_context: dict[str, str] | None = None,
+        context_extractor: Callable[[Request], dict[str, str]] | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._exclude_paths = set(exclude_paths or [])
         self._extra_context: dict[str, str] = extra_context or {}
+        self._context_extractor = context_extractor
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         if request.url.path in self._exclude_paths:
@@ -38,11 +57,16 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
         start = time.perf_counter()
         structlog.contextvars.clear_contextvars()
+        dynamic_context: dict[str, str] = {}
+        if self._context_extractor is not None:
+            with contextlib.suppress(Exception):
+                dynamic_context = self._context_extractor(request)
         structlog.contextvars.bind_contextvars(
             request_id=request_id_var.get(),
             method=request.method,
             path=request.url.path,
             **self._extra_context,
+            **dynamic_context,
         )
         logger.info("request.received")
         response = await call_next(request)

--- a/tests/nene2/middleware/test_request_logging.py
+++ b/tests/nene2/middleware/test_request_logging.py
@@ -95,3 +95,81 @@ def test_exclude_paths_passes_requests_through() -> None:
     client = TestClient(app)
     assert client.get("/health").status_code == 200
     assert client.get("/items").status_code == 200
+
+
+def test_context_extractor_adds_dynamic_context() -> None:
+    """context_extractor が返した値がログコンテキストに含まれる。"""
+    captured: list[dict] = []
+    app = FastAPI()
+    app.add_middleware(
+        RequestLoggingMiddleware,
+        context_extractor=lambda req: {"user_id": req.headers.get("X-User-Id", "anon")},
+    )
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        captured.append(dict(structlog.contextvars.get_contextvars()))
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    client.get("/ping", headers={"X-User-Id": "user-42"})
+    assert captured[0]["user_id"] == "user-42"
+
+
+def test_context_extractor_default_is_none() -> None:
+    """context_extractor を省略した場合は従来通り動作する。"""
+    captured: list[dict] = []
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        captured.append(dict(structlog.contextvars.get_contextvars()))
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    client.get("/ping")
+    assert "user_id" not in captured[0]
+
+
+def test_context_extractor_exception_is_silently_skipped() -> None:
+    """context_extractor が例外を投げてもリクエスト処理が続行される。"""
+    app = FastAPI()
+
+    def _exploding_extractor(req: object) -> dict[str, str]:
+        raise RuntimeError("extractor failure")
+
+    app.add_middleware(RequestLoggingMiddleware, context_extractor=_exploding_extractor)
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ping")
+    assert r.status_code == 200  # ログの失敗がリクエスト処理を壊さない
+
+
+def test_context_extractor_merges_with_extra_context() -> None:
+    """context_extractor と extra_context が両方指定されても正しくマージされる。"""
+    captured: list[dict] = []
+    app = FastAPI()
+    app.add_middleware(
+        RequestLoggingMiddleware,
+        extra_context={"service": "my-api"},
+        context_extractor=lambda req: {"user_id": "user-1"},
+    )
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        captured.append(dict(structlog.contextvars.get_contextvars()))
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    client.get("/ping")
+    assert captured[0]["service"] == "my-api"
+    assert captured[0]["user_id"] == "user-1"


### PR DESCRIPTION
## Summary

- `RequestLoggingMiddleware` に `context_extractor: Callable[[Request], dict[str, str]] | None` を追加
- リクエストごとの動的なログコンテキスト（JWT からの user_id、テナントID等）を注入可能に

## 使用例

```python
def get_log_context(request: Request) -> dict[str, str]:
    return {"user_id": request.headers.get("X-User-Id", "anonymous")}

app.add_middleware(
    RequestLoggingMiddleware,
    context_extractor=get_log_context,
)
```

## 動作

- `context_extractor` が例外を投げても `contextlib.suppress` でシレントにスキップ
  — ログの失敗がリクエスト処理を壊さない
- `extra_context`（静的）と `context_extractor`（動的）は両方指定可能（マージされる）
- 後方互換性: `context_extractor=None` がデフォルトで従来通り動作

## Test plan

- [x] `test_context_extractor_adds_dynamic_context`
- [x] `test_context_extractor_default_is_none`
- [x] `test_context_extractor_exception_is_silently_skipped`
- [x] `test_context_extractor_merges_with_extra_context`

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)