### PR TITLE
feat: setup_middlewares() に CORS サポートを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-81.md
+++ b/docs/field-trials/2026-05-field-trial-81.md
@@ -1,0 +1,198 @@
+# FT81: CORS 設定 — setup_middlewares() と CORSMiddleware の組み合わせ
+
+**日付**: 2026-05-20  
+**テーマ**: setup_middlewares() に CORS サポートがない場合の正しい設定パターン検証  
+**バージョン**: v1.8.26  
+**FTディレクトリ**: `/home/xi/docker/nene2-python-FT/ft81-cors/`
+
+---
+
+## 概要
+
+nene2 の `setup_middlewares()` は CORS をサポートしていないため、
+ブラウザから API を呼び出すアプリで CORS が必要になった際に
+ユーザーは `CORSMiddleware` を手動で追加する必要がある。
+その際、Starlette の LIFO ミドルウェア順序を理解していないと
+OPTIONS プリフライトが正常に動作しない問題を確認した。
+
+---
+
+## 実装パターン
+
+### 正しい CORS 設定（CORS を最外側に配置）
+
+```python
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from nene2.middleware import setup_middlewares
+
+ALLOWED_ORIGINS = [
+    "https://app.example.com",
+    "https://admin.example.com",
+]
+
+app = FastAPI()
+
+# ✅ CORS を先に add_middleware → setup_middlewares() 後は LIFO で最外側になる
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
+    allow_credentials=True,
+)
+setup_middlewares(app)
+```
+
+### 間違ったパターン（CORS が内側になる）
+
+```python
+# ❌ setup_middlewares() の後に CORS を追加すると内側に入る
+app = FastAPI()
+setup_middlewares(app)
+app.add_middleware(CORSMiddleware, allow_origins=["https://app.example.com"])
+# → OPTIONS プリフライトが nene2 ミドルウェアに遮断される可能性がある
+```
+
+### 禁止パターン（CLAUDE.md ポリシー違反）
+
+```python
+# ❌ CLAUDE.md 明示禁止: allow_origins=["*"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # セキュリティリスク
+)
+```
+
+---
+
+## 発見した問題
+
+### 問題1: setup_middlewares() に CORS パラメーターがない
+
+```python
+# CORS が必要でも setup_middlewares() のシグネチャに cors パラメーターなし
+setup_middlewares(
+    app,
+    # cors_allowed_origins=["https://app.example.com"],  # 存在しない
+)
+```
+
+ユーザーは `FastAPI.add_middleware(CORSMiddleware, ...)` を直接呼ぶ必要がある。
+FastAPI/Starlette のドキュメントを参照しなければ方法がわからない。
+
+### 問題2: ミドルウェア順序が直感に反する（LIFO）
+
+```python
+# Starlette は LIFO — 最後に add_middleware したものが最外側になる
+# つまり CORS を「最外側にしたい」なら「最初に add する」
+
+app.add_middleware(CORSMiddleware, ...)  # ← 先に追加 = 最外側（正しい）
+setup_middlewares(app)                   # ← 後から追加 = 内側
+
+# 逆にすると:
+setup_middlewares(app)                   # ← 先に追加 = 最内側（危険）
+app.add_middleware(CORSMiddleware, ...)  # ← 後から追加 = 最外側になってしまう
+```
+
+「最外側に置きたいなら先に add する」という反直感的な順序。
+
+### 問題3: nene2 が allow_origins=["*"] を禁止しない
+
+```python
+# CLAUDE.md で明示禁止されているが、nene2 フレームワークは検証しない
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # 禁止ポリシーだが動作してしまう
+)
+```
+
+フレームワークレベルで `ValueError` を raise することも可能だが、
+`setup_middlewares()` を経由しない場合は検証できない。
+
+### 問題4: 複数オリジン・credentials 設定パターンがドキュメントにない
+
+本番アプリでは複数オリジン（本番環境 + ステージング環境）や
+`allow_credentials=True` が必要なケースが多いが、
+nene2 のドキュメントにこのパターンの記載がない。
+
+---
+
+## テスト結果（全13件パス）
+
+```
+test_list_items_returns_200                            PASSED
+test_create_item_returns_201                           PASSED
+test_cors_allowed_origin_returns_access_control_header PASSED
+test_cors_disallowed_origin_no_access_control_header   PASSED
+test_cors_preflight_options_returns_200                PASSED  # OPTIONS プリフライト正常動作
+test_cors_preflight_disallowed_origin                  PASSED
+test_cors_credentials_allowed                          PASSED
+test_security_headers_present_with_cors               PASSED  # nene2 ミドルウェアと共存
+test_request_id_present_with_cors                     PASSED  # X-Request-Id と共存
+test_friction_no_cors_in_setup_middlewares             PASSED  # 摩擦: CORS パラメーターなし
+test_friction_cors_order_matters                       PASSED  # 摩擦: LIFO 順序問題
+test_friction_wildcard_origin_is_insecure              PASSED  # 摩擦: ["*"] を止めない
+test_friction_multiple_origins_not_documented          PASSED  # 摩擦: ドキュメント不足
+```
+
+---
+
+## 摩擦ポイント一覧
+
+| ID | 内容 | 深刻度 |
+|---|---|---|
+| F81-1 | `setup_middlewares()` に CORS パラメーターがなく手動追加が必要 | 中 |
+| F81-2 | Starlette の LIFO 順序を知らないと OPTIONS プリフライトが壊れる | 中 |
+| F81-3 | `allow_origins=["*"]` を nene2 が禁止しない（ポリシーのみ） | 低 |
+| F81-4 | 複数オリジン・credentials パターンがドキュメントに未記載 | 低 |
+
+---
+
+## 使用感（主観評価）
+
+### 直感性 ★★★☆☆
+
+`setup_middlewares()` を使うと CORS は自分で追加しなければならず、
+しかも「先に add する = 最外側になる」という反直感的な順序ルールがある。
+FastAPI や Express.js、Spring Security の CORS 設定を知っているユーザーでも
+nene2 特有の LIFO 順序で一度はつまずく。
+
+### 実害の深刻さ ★★★☆☆
+
+ブラウザからの CORS エラーは「API が動かない」として即座に表面化する。
+原因が「ミドルウェア順序」であることを特定するのに時間がかかることがある。
+特に OPTIONS プリフライトが通らないと PUT/DELETE/POST with Auth が全滅する。
+
+### 修正のしやすさ ★★★★★
+
+`setup_middlewares()` に `cors_allowed_origins` パラメーターを追加するだけ。
+CORS は最外側（最初の add_middleware）に固定できるため、
+ユーザーが順序を気にする必要がなくなる。
+
+```python
+# 理想の API:
+setup_middlewares(
+    app,
+    cors_allowed_origins=["https://app.example.com"],
+    cors_allow_credentials=True,
+)
+```
+
+### 総合コメント
+
+CORS は「作ったら必ず必要になる」機能でありながら、
+nene2 の `setup_middlewares()` には組み込まれていない。
+`["*"]` 禁止は CLAUDE.md のポリシーとして正しいが、
+フレームワークが強制しないと誰かが違反する。
+`cors_allowed_origins` を追加してワイルドカードを `ValueError` にすれば
+セキュリティポリシーをコードで強制できる。
+
+---
+
+## 推奨アクション
+
+1. **Issue**: `setup_middlewares()` に `cors_allowed_origins` パラメーターを追加
+   — `allow_origins=["*"]` を渡した場合に `ValueError` を raise
+   — CORS を最外側に自動配置（ユーザーが順序を意識しなくていい）
+2. **docs**: 複数オリジン・credentials のパターンを how-to ガイドに追加

--- a/src/nene2/middleware/setup.py
+++ b/src/nene2/middleware/setup.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
 
 from .domain_exception import DomainExceptionHandlerProtocol
 from .error_handler import ErrorHandlerMiddleware
@@ -13,6 +14,10 @@ from .security_headers import SecurityHeadersMiddleware
 from .throttle import ThrottleMiddleware
 
 _DEFAULT_MAX_BYTES = 1_048_576  # 1 MiB
+
+
+_CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+_CORS_ALLOW_HEADERS = ["Authorization", "Content-Type"]
 
 
 def setup_middlewares(
@@ -32,6 +37,10 @@ def setup_middlewares(
     hsts: bool = False,
     csp: str | None = None,
     security_extra_no_csp_paths: list[str] | None = None,
+    cors_allowed_origins: list[str] | None = None,
+    cors_allow_credentials: bool = False,
+    cors_allow_methods: list[str] | None = None,
+    cors_allow_headers: list[str] | None = None,
 ) -> None:
     """Register all nene2 middlewares in the correct order.
 
@@ -41,7 +50,7 @@ def setup_middlewares(
 
     Effective stack (outermost → innermost)::
 
-        RequestId → SecurityHeaders → SizeLimit → Throttle → RequestLogging → ErrorHandler
+        CORS → RequestId → SecurityHeaders → SizeLimit → Throttle → RequestLogging → ErrorHandler
 
     **Minimal usage** — all options have sensible defaults::
 
@@ -49,6 +58,14 @@ def setup_middlewares(
 
         app = FastAPI()
         setup_middlewares(app)
+
+    **With CORS** (explicit origins required — wildcards are rejected)::
+
+        setup_middlewares(
+            app,
+            cors_allowed_origins=["https://app.example.com"],
+            cors_allow_credentials=True,
+        )
 
     **With customisation**::
 
@@ -103,13 +120,29 @@ def setup_middlewares(
         hsts: Enable Strict-Transport-Security header (default: False).
         csp: Custom Content-Security-Policy value. Defaults to nene2's built-in policy.
         security_extra_no_csp_paths: Additional paths to skip CSP (on top of /docs, /redoc).
+        cors_allowed_origins: Explicit list of allowed CORS origins.
+            Pass ``None`` (default) to skip :class:`CORSMiddleware`.
+            Passing ``["*"]`` raises :exc:`ValueError` — wildcard origins are forbidden
+            per nene2 security policy.
+        cors_allow_credentials: Allow cookies and ``Authorization`` headers in CORS
+            requests (default: False).
+        cors_allow_methods: HTTP methods exposed via CORS
+            (default: GET, POST, PUT, PATCH, DELETE, OPTIONS).
+        cors_allow_headers: Request headers exposed via CORS
+            (default: Authorization, Content-Type).
     """
     if not isinstance(app, Starlette):
         raise TypeError(f"app must be a Starlette/FastAPI instance, got {type(app)!r}")
 
+    if cors_allowed_origins is not None and "*" in cors_allowed_origins:
+        raise ValueError(
+            "cors_allowed_origins must not contain '*'. "
+            "wildcard CORS origins are forbidden — list explicit origins instead."
+        )
+
     # Add in reverse order — first added = innermost, last added = outermost.
     # Desired outermost → innermost:
-    #   RequestId → SecurityHeaders → SizeLimit → Throttle → RequestLogging → ErrorHandler
+    #   CORS → RequestId → SecurityHeaders → SizeLimit → Throttle → RequestLogging → ErrorHandler
 
     # 1. Innermost: ErrorHandlerMiddleware (also registers RequestValidationError handler)
     ErrorHandlerMiddleware.install(app, debug=debug, domain_handlers=domain_handlers)
@@ -144,5 +177,16 @@ def setup_middlewares(
             sec_kwargs["extra_no_csp_paths"] = security_extra_no_csp_paths
         app.add_middleware(SecurityHeadersMiddleware, **sec_kwargs)
 
-    # 6. Outermost: RequestIdMiddleware
+    # 6. RequestIdMiddleware
     app.add_middleware(RequestIdMiddleware)
+
+    # 7. Outermost: CORSMiddleware (optional) — must be outermost so OPTIONS preflight
+    #    responses are handled before any other middleware processes the request.
+    if cors_allowed_origins is not None:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_allowed_origins,
+            allow_credentials=cors_allow_credentials,
+            allow_methods=cors_allow_methods or _CORS_ALLOW_METHODS,
+            allow_headers=cors_allow_headers or _CORS_ALLOW_HEADERS,
+        )

--- a/tests/nene2/middleware/test_setup_middlewares.py
+++ b/tests/nene2/middleware/test_setup_middlewares.py
@@ -122,3 +122,68 @@ def test_pydantic_422_formatted_as_nene2() -> None:
 def test_raises_type_error_for_non_starlette_app() -> None:
     with pytest.raises(TypeError, match="Starlette/FastAPI"):
         setup_middlewares(object())
+
+
+def test_cors_allowed_origin_returns_access_control_header() -> None:
+    app = _make_app(cors_allowed_origins=["https://app.example.com"])
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://app.example.com"})
+    assert r.headers.get("access-control-allow-origin") == "https://app.example.com"
+
+
+def test_cors_disallowed_origin_no_header() -> None:
+    app = _make_app(cors_allowed_origins=["https://app.example.com"])
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://evil.example.com"})
+    assert "access-control-allow-origin" not in r.headers
+
+
+def test_cors_preflight_options_returns_200() -> None:
+    app = _make_app(cors_allowed_origins=["https://app.example.com"])
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.options(
+        "/ok",
+        headers={
+            "Origin": "https://app.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://app.example.com"
+
+
+def test_cors_wildcard_origin_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="wildcard"):
+        _make_app(cors_allowed_origins=["*"])
+
+
+def test_cors_none_means_no_cors_middleware() -> None:
+    app = _make_app(cors_allowed_origins=None)
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://app.example.com"})
+    assert "access-control-allow-origin" not in r.headers
+
+
+def test_cors_credentials_can_be_enabled() -> None:
+    app = _make_app(
+        cors_allowed_origins=["https://app.example.com"],
+        cors_allow_credentials=True,
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://app.example.com"})
+    assert r.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_cors_request_id_still_present() -> None:
+    """CORS ミドルウェアと X-Request-Id が共存する。"""
+    app = _make_app(cors_allowed_origins=["https://app.example.com"])
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://app.example.com"})
+    assert "x-request-id" in r.headers
+
+
+def test_cors_security_headers_still_present() -> None:
+    """CORS ミドルウェアとセキュリティヘッダーが共存する。"""
+    app = _make_app(cors_allowed_origins=["https://app.example.com"])
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.get("/ok", headers={"Origin": "https://app.example.com"})
+    assert r.headers.get("x-content-type-options") == "nosniff"


### PR DESCRIPTION
## Summary
- `cors_allowed_origins` パラメーターを追加し `CORSMiddleware` を最外側に自動配置
- `allow_origins=["*"]` を渡すと `ValueError` を raise（CLAUDE.md wildcard 禁止ポリシーを実装レベルで強制）
- `cors_allow_credentials` / `cors_allow_methods` / `cors_allow_headers` オプションを追加
- CORS 関連テストを 8 件追加（OPTIONS preflight、disallowed origin、wildcard rejection 等）

Closes #346

## Test plan
- [x] `test_cors_allowed_origin_returns_access_control_header`
- [x] `test_cors_disallowed_origin_no_header`
- [x] `test_cors_preflight_options_returns_200`
- [x] `test_cors_wildcard_origin_raises_value_error`
- [x] `test_cors_none_means_no_cors_middleware`
- [x] `test_cors_credentials_can_be_enabled`
- [x] `test_cors_request_id_still_present`
- [x] `test_cors_security_headers_still_present`

🤖 Generated with [Claude Code](https://claude.com/claude-code)