### PR TITLE
docs: FT97 HTTP キャッシュヘッダー フィールドトライアルレポートと CHANGELOG v1.8.31 を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.31] — 2026-05-20
+
+FT97 フィールドトライアル — HTTP キャッシュヘッダーパターン検証と generate_etag() 追加。
+
+### Added
+- `nene2.http.generate_etag(data)` — ETag 生成ユーティリティ関数を追加 (#397) (FT97)
+  — dict / list / str / bytes から RFC 9110 形式の ETag 文字列を生成
+  — HTTP キャッシュ (`If-None-Match` / `304 Not Modified`) パターンで利用
+- Field trial reports: `docs/field-trials/2026-05-field-trial-92.md` 〜 `2026-05-field-trial-97.md` (FT92〜FT97)
+
+---
+
 ## [1.8.30] — 2026-05-20
 
 FT87 フィールドトライアル — カスタムレスポンスヘッダーパターン検証と problem_details_response() 改善。

--- a/docs/field-trials/2026-05-field-trial-97.md
+++ b/docs/field-trials/2026-05-field-trial-97.md
@@ -1,0 +1,87 @@
+# Field Trial 97: HTTP キャッシュヘッダー (ETag / Cache-Control)
+
+**日付**: 2026-05-20
+**テーマ**: ETag・Cache-Control・304 Not Modified パターンを nene2 で実装
+**バージョン**: v1.8.30
+**結果**: 摩擦あり（コード修正なし）
+
+---
+
+## 目的
+
+HTTP キャッシュ機構（`ETag`, `Cache-Control`, `If-None-Match`, `304 Not Modified`）を nene2 ベースの API で実装するパターンを検証する。
+
+---
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft97-http-caching/` に以下を実装:
+
+- `app.py` — ETag 付き GET エンドポイント、`If-None-Match` による 304 返却、Cache-Control ヘッダー
+- 13 テスト（全 PASS）
+
+---
+
+## 確認できた良好な動作
+
+### ETag + 304 のパターン
+
+`If-None-Match` ヘッダーと ETag を比較して 304 を返すパターンは問題なく動作する。
+
+```python
+@app.get("/articles/{article_id}")
+def get_article(article_id: int, request: Request) -> Response:
+    data = _article_to_dict(article)
+    etag = _compute_etag(data)
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers={"ETag": etag})
+
+    return JSONResponse(data, headers={"ETag": etag, "Cache-Control": "max-age=60"})
+```
+
+### 304 レスポンスにも X-Request-Id が付く
+
+`Response(status_code=304)` を返しても、外側の `RequestIdMiddleware` が `X-Request-Id` を付与する。
+
+---
+
+## 摩擦点
+
+### F97-1: nene2 に ETag 生成ユーティリティがない
+
+ETag 生成ロジック（MD5 ハッシュ）を各プロジェクトで手動実装する必要がある。各エンドポイントで繰り返し実装することになり DRY でない。
+
+```python
+def _compute_etag(data: object) -> str:
+    content = json.dumps(data, sort_keys=True, ensure_ascii=False)
+    return f'"{hashlib.md5(content.encode(), usedforsecurity=False).hexdigest()}"'
+```
+
+nene2 が `generate_etag(data)` などのユーティリティ関数を提供すれば再実装不要になる。
+
+### F97-2: `hashlib.md5()` に `usedforsecurity=False` が必要
+
+ruff のセキュリティルール `S324`（MD5 使用禁止）により、ETag 生成で `hashlib.md5()` を使うと lint エラーになる。ETag は暗号セキュリティ用途ではないが、明示的に `usedforsecurity=False` を指定する必要がある。
+
+```python
+# ❌ ruff S324 エラー
+hashlib.md5(content.encode()).hexdigest()
+
+# ✅ 正しい
+hashlib.md5(content.encode(), usedforsecurity=False).hexdigest()
+```
+
+nene2 のユーティリティ関数でラップすればプロジェクトごとに対処不要になる。
+
+### F97-3: Cache-Control ヘッダーの付与はエンドポイントごとに手動
+
+`JSONResponse(headers={"Cache-Control": "max-age=60"})` のように各エンドポイントで手動指定が必要。
+ミドルウェアでのデフォルト付与（例: 全 GET に `Cache-Control: no-cache` を付与する設定）がないため、付け忘れが起きやすい。
+
+---
+
+## 結論
+
+HTTP キャッシュヘッダーは nene2 と問題なく実装できるが、ETag 生成の共通化がない。
+`generate_etag()` などのユーティリティ関数を nene2 に追加することで摩擦を解消できる。


### PR DESCRIPTION
## Summary
- FT97 で ETag / Cache-Control / 304 Not Modified パターンを検証
- 摩擦点: ETag ユーティリティなし → generate_etag() を v1.8.31 で追加済み
- CHANGELOG に v1.8.31 エントリを追加

Closes #399

## Test plan
- [ ] CI pass (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)