### PR TITLE
docs: 未対応 how-to ガイドを一括追加（13 issues 対応）

### DIFF
--- a/docs/how-to/async-use-case.md
+++ b/docs/how-to/async-use-case.md
@@ -119,3 +119,44 @@ inspect.iscoroutinefunction(use_case.execute)  # → True/False
 ```
 
 型安全性は `mypy --strict` の静的解析で保証します。詳細は ADR-0010 を参照してください。
+
+---
+
+## 同期 DB 呼び出しのブロッキング問題
+
+`async def` ハンドラーで同期の DB 呼び出し（SQLAlchemy sync API 等）を行うと、イベントループをブロックして他のリクエストが詰まる。
+
+```python
+# ❌ async def 内での同期 DB 呼び出しはブロッキング
+@app.get("/notes")
+async def list_notes() -> JSONResponse:
+    notes = session.execute(select(Note)).scalars().all()  # ブロック！
+    return JSONResponse(...)
+```
+
+**解決策1: `run_in_threadpool` でスレッドプールで実行する**
+
+```python
+from nene2.middleware import run_in_threadpool
+
+@app.get("/notes")
+async def list_notes() -> JSONResponse:
+    notes = await run_in_threadpool(session.execute, select(Note))
+    return JSONResponse(...)
+```
+
+**解決策2: `def`（同期）ハンドラーを使う**
+
+同期 DB を使う場合は、ハンドラーを `async def` にしない。FastAPI が自動でスレッドプールで実行する。
+
+```python
+# ✅ def ハンドラー + 同期 DB = 問題なし
+@app.get("/notes")
+def list_notes() -> JSONResponse:
+    notes = session.execute(select(Note)).scalars().all()
+    return JSONResponse(...)
+```
+
+**解決策3: SQLAlchemy async API に移行する**
+
+長期的には SQLAlchemy の async API（`AsyncSession`）への移行を検討する。

--- a/docs/how-to/background-tasks.md
+++ b/docs/how-to/background-tasks.md
@@ -1,0 +1,101 @@
+# How-to: BackgroundTasks
+
+FastAPI の `BackgroundTasks` を使ってレスポンス後に処理を実行するパターンを説明する。
+
+---
+
+## 1. 基本パターン
+
+```python
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+def send_notification(message: str) -> None:
+    # 時間がかかる処理（メール送信・外部 API 呼び出し等）
+    print(f"Sending: {message}")
+
+@app.post("/orders", status_code=201)
+def create_order(
+    body: CreateOrderBody,
+    background_tasks: BackgroundTasks,
+) -> JSONResponse:
+    order = process_order(body)
+    background_tasks.add_task(send_notification, f"Order {order.order_id} created")
+    return JSONResponse({"order_id": order.order_id}, status_code=201)
+```
+
+---
+
+## 2. UseCase との分離
+
+UseCase を HTTP 非依存に保つため、`BackgroundTasks` は UseCase に渡さない。ハンドラー層でイベントを受け取り、BackgroundTasks に追加する。
+
+```python
+# ✅ UseCase は BackgroundTasks を知らない
+class CreateOrderUseCase:
+    def execute(self, body: CreateOrderInput) -> CreateOrderOutput:
+        order = Order(...)
+        return CreateOrderOutput(order_id=order.order_id, notify_email=body.email)
+
+# ハンドラー層で BackgroundTasks を使う
+@app.post("/orders", status_code=201)
+def create_order(
+    body: CreateOrderBody,
+    background_tasks: BackgroundTasks,
+    use_case: CreateOrderUseCase = Depends(get_use_case),
+) -> JSONResponse:
+    result = use_case.execute(CreateOrderInput(email=body.email))
+    background_tasks.add_task(send_notification, result.notify_email)
+    return JSONResponse({"order_id": result.order_id}, status_code=201)
+```
+
+---
+
+## 3. TestClient での挙動
+
+`TestClient` では `BackgroundTasks` がレスポンス返却 **前** に同期的に実行される。
+
+```python
+executed: list[str] = []
+
+def track_task(msg: str) -> None:
+    executed.append(msg)
+
+# テストでは BackgroundTasks が同期実行される
+r = client.post("/orders", json={"email": "alice@example.com"})
+assert r.status_code == 201
+assert len(executed) == 1  # すでに実行済み
+```
+
+本番環境では非同期実行（レスポンス後）だが、テストでは同期実行されることに注意。
+
+---
+
+## 4. 失敗しても 500 にならない
+
+`BackgroundTasks` 内で例外が発生しても、レスポンスはすでに送信済みのため 500 にはならない。エラーはログに記録される。
+
+```python
+def risky_task() -> None:
+    raise RuntimeError("Background task failed")
+
+# レスポンスは 201 で返る（バックグラウンドエラーは隠れる）
+background_tasks.add_task(risky_task)
+```
+
+重要な処理は BackgroundTasks に頼らず、ジョブキュー（Celery・ARQ 等）を使う。
+
+---
+
+## 5. async def との組み合わせ
+
+`background_tasks.add_task()` には同期・非同期どちらの関数も渡せる。
+
+```python
+async def async_notification(email: str) -> None:
+    await send_email_async(email)
+
+background_tasks.add_task(async_notification, user.email)
+```

--- a/docs/how-to/cors.md
+++ b/docs/how-to/cors.md
@@ -1,0 +1,87 @@
+# How-to: CORS 設定
+
+`setup_middlewares()` の `cors_allowed_origins` パラメーターで CORS を有効化する方法を説明する。
+
+---
+
+## 1. 基本: 単一オリジンを許可
+
+```python
+from nene2.middleware import setup_middlewares
+
+app = FastAPI()
+setup_middlewares(app, cors_allowed_origins=["https://example.com"])
+```
+
+`cors_allowed_origins` を指定しない（デフォルト `None`）と CORS ミドルウェアは追加されない。
+
+---
+
+## 2. 複数オリジンを許可
+
+```python
+setup_middlewares(app, cors_allowed_origins=[
+    "https://app.example.com",
+    "https://admin.example.com",
+])
+```
+
+---
+
+## 3. 開発環境: localhost を許可
+
+```python
+import os
+
+origins = ["https://app.example.com"]
+if os.getenv("APP_ENV") == "local":
+    origins += ["http://localhost:3000", "http://localhost:5173"]
+
+setup_middlewares(app, cors_allowed_origins=origins)
+```
+
+**`allow_origins=["*"]` は禁止**。CLAUDE.md のセキュリティポリシーにより、ワイルドカードオリジンは開発環境でも使用不可。
+
+---
+
+## 4. credentials（Cookie・Authorization ヘッダー）を許可
+
+`setup_middlewares()` は内部で `allow_credentials=True` を設定しない。credentials が必要な場合は `CORSMiddleware` を直接追加する。
+
+```python
+from starlette.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+setup_middlewares(app)  # 他のミドルウェア（RequestId 等）は通常通り設定
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://app.example.com"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+**注意**: `add_middleware` は LIFO のため、`CORSMiddleware` を後から追加すると最外側に配置される。`setup_middlewares()` の後に呼ぶことで、CORS が最も外側で処理される。
+
+---
+
+## 5. CORS とプリフライトリクエスト
+
+`OPTIONS` リクエスト（プリフライト）は `CORSMiddleware` が自動で処理する。`@app.options(...)` を定義する必要はない。
+
+---
+
+## 6. テストでの CORS ヘッダー確認
+
+```python
+def test_cors_header() -> None:
+    with TestClient(app) as client:
+        r = client.get("/items", headers={"Origin": "https://app.example.com"})
+        assert r.headers.get("access-control-allow-origin") == "https://app.example.com"
+
+def test_cors_not_allowed_for_unknown_origin() -> None:
+    with TestClient(app) as client:
+        r = client.get("/items", headers={"Origin": "https://evil.com"})
+        assert "access-control-allow-origin" not in r.headers
+```

--- a/docs/how-to/domain-events.md
+++ b/docs/how-to/domain-events.md
@@ -1,0 +1,119 @@
+# How-to: ドメインイベントパターン
+
+UseCase 実行後のサイドエフェクト（メール送信・ログ・通知）を、ドメインイベントと BackgroundTasks で分離するパターンを説明する。
+
+---
+
+## 1. 基本パターン: BackgroundTasks でイベントを非同期実行
+
+FastAPI の `BackgroundTasks` でレスポンス後に処理を実行する。
+
+```python
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.responses import JSONResponse
+
+def send_welcome_email(email: str) -> None:
+    # メール送信処理（時間がかかる）
+    ...
+
+@app.post("/users", status_code=201)
+def create_user(body: CreateUserBody, background_tasks: BackgroundTasks) -> JSONResponse:
+    user = create_user_use_case(body.name, body.email)
+    background_tasks.add_task(send_welcome_email, user.email)
+    return JSONResponse({"user_id": user.user_id}, status_code=201)
+```
+
+---
+
+## 2. EventBus パターン: UseCase からドメインイベントを発行
+
+UseCase がイベントを発行し、ハンドラーが購読するパターン。UseCase は HTTP 知識（BackgroundTasks）を持たない。
+
+```python
+from dataclasses import dataclass
+from typing import Any, Callable
+
+# イベント定義
+@dataclass(frozen=True, slots=True)
+class UserCreatedEvent:
+    user_id: int
+    email: str
+
+# EventBus
+type EventHandler = Callable[[Any], None]
+
+class EventBus:
+    def __init__(self) -> None:
+        self._handlers: dict[type, list[EventHandler]] = {}
+
+    def subscribe(self, event_type: type, handler: EventHandler) -> None:
+        self._handlers.setdefault(event_type, []).append(handler)
+
+    def publish(self, event: object) -> None:
+        for handler in self._handlers.get(type(event), []):
+            handler(event)
+
+event_bus = EventBus()
+
+# UseCase: HTTP 非依存
+class CreateUserUseCase:
+    def __init__(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+
+    def execute(self, name: str, email: str) -> User:
+        user = User(...)
+        self._event_bus.publish(UserCreatedEvent(user.user_id, user.email))
+        return user
+
+# ハンドラー登録
+def on_user_created(event: UserCreatedEvent) -> None:
+    send_welcome_email(event.email)
+
+event_bus.subscribe(UserCreatedEvent, on_user_created)
+```
+
+---
+
+## 3. BackgroundTasks と EventBus の組み合わせ
+
+HTTP ハンドラーで BackgroundTasks を使い、EventBus のハンドラーをバックグラウンドで実行する。
+
+```python
+@app.post("/users", status_code=201)
+def create_user(
+    body: CreateUserBody,
+    background_tasks: BackgroundTasks,
+    use_case: CreateUserUseCase = Depends(get_create_user_use_case),
+) -> JSONResponse:
+    # UseCase はイベントを同期発行（EventBus に積む）
+    user = use_case.execute(body.name, body.email)
+    # BackgroundTasks でイベント処理をレスポンス後に実行
+    for handler_call in collected_events:
+        background_tasks.add_task(handler_call)
+    return JSONResponse({"user_id": user.user_id}, status_code=201)
+```
+
+---
+
+## 4. テストでのイベント確認
+
+テスト時は BackgroundTasks の実行を待たずに完了するため、TestClient では同期的にすぐ実行される。
+
+```python
+# TestClient では BackgroundTasks がレスポンス返却前に同期実行される
+executed = []
+event_bus.subscribe(UserCreatedEvent, lambda e: executed.append(e))
+
+with TestClient(app) as client:
+    r = client.post("/users", json={"name": "Alice", "email": "alice@example.com"})
+
+assert len(executed) == 1  # BackgroundTasks は完了済み
+assert executed[0].email == "alice@example.com"
+```
+
+---
+
+## 注意点
+
+- `EventBus` はモジュールレベルのグローバル変数になりやすい。テスト間でハンドラーが蓄積する場合は `autouse` fixture でリセットする。
+- UseCase 内でイベントを発行する場合、UseCase の引数に `EventBus` を渡してコンストラクタインジェクションする（グローバル参照を避ける）。

--- a/docs/how-to/file-upload.md
+++ b/docs/how-to/file-upload.md
@@ -1,0 +1,142 @@
+# How-to: ファイルアップロード
+
+FastAPI の `UploadFile` を使ったファイルアップロードパターンを説明する。
+
+---
+
+## 1. 基本パターン
+
+```python
+from fastapi import FastAPI, UploadFile
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+@app.post("/upload", status_code=201)
+async def upload_file(file: UploadFile) -> JSONResponse:
+    content = await file.read()
+    return JSONResponse({
+        "filename": file.filename,
+        "size": len(content),
+        "content_type": file.content_type,
+    }, status_code=201)
+```
+
+**`await file.read()` は `async def` が必要**。`def`（同期）ハンドラーでは使えない。
+
+---
+
+## 2. コンテントタイプの検証
+
+FastAPI は `content_type` を自動検証しない。手動でチェックする。
+
+```python
+ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
+
+@app.post("/images", status_code=201)
+async def upload_image(file: UploadFile) -> JSONResponse:
+    if file.content_type not in ALLOWED_TYPES:
+        return problem_details_response(
+            "invalid-content-type",
+            "Invalid Content Type",
+            415,
+            f"Allowed types: {', '.join(ALLOWED_TYPES)}",
+        )
+    content = await file.read()
+    return JSONResponse({"filename": file.filename, "size": len(content)}, status_code=201)
+```
+
+---
+
+## 3. マジックバイト（ファイルシグネチャ）による検証
+
+Content-Type ヘッダーは偽装できる。ファイルの先頭バイト（マジックバイト）でファイル形式を確認する。
+
+```python
+MAGIC_BYTES: dict[bytes, str] = {
+    b"\xff\xd8\xff": "image/jpeg",
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"RIFF": "image/webp",  # WebP は RIFF ヘッダー
+}
+
+def detect_image_type(data: bytes) -> str | None:
+    for magic, mime_type in MAGIC_BYTES.items():
+        if data.startswith(magic):
+            return mime_type
+    return None
+
+@app.post("/images/secure", status_code=201)
+async def upload_image_secure(file: UploadFile) -> JSONResponse:
+    content = await file.read()
+    detected = detect_image_type(content)
+    if detected is None:
+        return problem_details_response(
+            "invalid-file-type", "Invalid File Type", 415,
+            "Only JPEG, PNG, WebP are allowed.",
+        )
+    return JSONResponse({
+        "filename": file.filename,
+        "detected_type": detected,
+        "size": len(content),
+    }, status_code=201)
+```
+
+---
+
+## 4. ファイルサイズ制限
+
+`setup_middlewares()` の `max_request_bytes` パラメーターで全リクエストのサイズを制限できる。
+
+```python
+setup_middlewares(app, max_request_bytes=10 * 1024 * 1024)  # 10 MB
+```
+
+エンドポイントごとに制限したい場合は手動チェック:
+
+```python
+MAX_SIZE = 5 * 1024 * 1024  # 5 MB
+
+@app.post("/upload")
+async def upload(file: UploadFile) -> JSONResponse:
+    content = await file.read()
+    if len(content) > MAX_SIZE:
+        return problem_details_response(
+            "file-too-large", "File Too Large", 413,
+            f"Maximum file size is {MAX_SIZE // 1024 // 1024} MB.",
+        )
+    ...
+```
+
+---
+
+## 5. テスト
+
+```python
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+def test_upload_image() -> None:
+    # 最小有効 JPEG（JPEG マジックバイト）
+    fake_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+    r = client.post(
+        "/images",
+        files={"file": ("test.jpg", BytesIO(fake_jpeg), "image/jpeg")},
+    )
+    assert r.status_code == 201
+```
+
+`files=` パラメーターで `(filename, fileobj, content_type)` のタプルを渡す。
+
+---
+
+## 注意: `max_request_bytes` のパラメーター名
+
+`setup_middlewares()` のパラメーター名は `max_request_bytes`（バイト数）。`max_request_size` は存在しない。
+
+```python
+# ✅ 正しい
+setup_middlewares(app, max_request_bytes=10_000_000)
+
+# ❌ TypeError
+setup_middlewares(app, max_request_size=10_000_000)
+```

--- a/docs/how-to/lifespan-and-app-state.md
+++ b/docs/how-to/lifespan-and-app-state.md
@@ -1,0 +1,109 @@
+# How-to: Lifespan と app.state
+
+FastAPI の `lifespan` コンテキストマネージャーと `app.state` を使ったリソース管理パターンを説明する。
+
+---
+
+## 1. Lifespan の基本パターン
+
+DB 接続・キャッシュ・外部クライアントなど、アプリ起動時に初期化して終了時にクリーンアップするリソースは `lifespan` で管理する。
+
+```python
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+from fastapi import FastAPI
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # 起動時: リソース初期化
+    app.state.db = await create_db_connection()
+    yield
+    # 終了時: クリーンアップ
+    await app.state.db.close()
+
+app = FastAPI(lifespan=lifespan)
+```
+
+---
+
+## 2. app.state の型安全なアクセス
+
+`app.state` は `starlette.datastructures.State` オブジェクトで、任意の属性を動的に追加できる。型アノテーションがないため、アクセス時に型チェックが効かない。
+
+**推奨: 型付きアクセサー関数を定義する**
+
+```python
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+def get_db(request: Request) -> AsyncSession:
+    db: AsyncSession = request.app.state.db  # type: ignore[attr-defined]  # reason: lifespan で確実に設定される
+    return db
+```
+
+または、型付きラッパーを定義する:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class AppState:
+    db: AsyncSession
+    cache: RedisClient
+
+def get_app_state(request: Request) -> AppState:
+    return AppState(
+        db=request.app.state.db,
+        cache=request.app.state.cache,
+    )
+```
+
+---
+
+## 3. TestClient と lifespan
+
+`TestClient` を通常の使い方（コンテキストマネージャーなし）だと、lifespan が実行されない。
+
+```python
+# ❌ lifespan が実行されない
+client = TestClient(app)
+r = client.get("/")  # app.state.db が未設定で AttributeError
+
+# ✅ with ブロックで lifespan を実行する
+with TestClient(app) as client:
+    r = client.get("/")  # lifespan が起動・終了する
+```
+
+ただし、別のテストが先に `with TestClient(app)` を実行していると `app.state` が持続し、`with` なしでも偶然動作することがある。これはテスト順依存のバグになりうるため、常に `with` ブロックを使う。
+
+**pytest fixture パターン**:
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+
+@pytest.fixture()
+def client() -> TestClient:
+    with TestClient(app) as c:
+        yield c
+```
+
+---
+
+## 4. app.state に設定した値が lifespan 後に消える
+
+`app.state` への設定は `lifespan` 内で行う。`startup` イベント（旧 API）は FastAPI 0.93+ では非推奨。
+
+```python
+# ❌ 旧 API（非推奨）
+@app.on_event("startup")
+async def startup() -> None:
+    app.state.db = await create_db_connection()
+
+# ✅ lifespan を使う
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.db = await create_db_connection()
+    yield
+    await app.state.db.close()
+```

--- a/docs/how-to/response-patterns.md
+++ b/docs/how-to/response-patterns.md
@@ -1,0 +1,110 @@
+# How-to: レスポンスパターン
+
+FastAPI + nene2 でのレスポンス返却パターンをまとめる。
+
+---
+
+## 1. JSONResponse + response_model の正しい組み合わせ
+
+`response_model` を指定したエンドポイントで `JSONResponse` を直接返すと、FastAPI はその内容を **バリデーションしない**。`response_model` は OpenAPI スキーマ生成にのみ使われる。
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+class NoteResponse(BaseModel):
+    note_id: int
+    title: str
+
+# ✅ response_model はスキーマのみ。JSONResponse の内容は直接送られる
+@app.get("/notes/{note_id}", response_model=NoteResponse)
+def get_note(note_id: int) -> JSONResponse:
+    return JSONResponse({"note_id": note_id, "title": "Hello"})
+```
+
+`response_model` を指定しない場合は `dict | list` を返せるが、OpenAPI スキーマが `{}` になる。スキーマを正確に出力したい場合は常に `response_model` を指定する。
+
+---
+
+## 2. Domain dataclass と Pydantic レスポンスモデルの二重定義
+
+nene2 ではドメイン層と HTTP 層を分離するため、同じフィールドを持つクラスが 2 つ生まれる。
+
+```python
+# ドメイン層: frozen dataclass（DB 返却値・UseCase の入出力）
+@dataclass(frozen=True, slots=True)
+class Note:
+    note_id: int
+    title: str
+
+# HTTP 層: Pydantic モデル（OpenAPI スキーマ生成・バリデーション）
+class NoteResponse(BaseModel):
+    note_id: int = Field(description="ノート ID")
+    title: str = Field(description="タイトル")
+```
+
+**なぜ二重になるか**: `dataclass` はドメインの不変条件を表す値オブジェクト、`Pydantic BaseModel` は HTTP 境界のシリアライズ/スキーマ定義。両者は責務が異なる。
+
+変換は手動で行う:
+
+```python
+def _note_to_dict(note: Note) -> dict[str, object]:
+    return {"note_id": note.note_id, "title": note.title}
+
+@app.get("/notes/{note_id}", response_model=NoteResponse)
+def get_note(note_id: int) -> JSONResponse:
+    note = repository.find(note_id)
+    return JSONResponse(_note_to_dict(note))
+```
+
+---
+
+## 3. problem_details_response() と JSONResponse の混在
+
+同じエンドポイントで成功時は `JSONResponse`、エラー時は `problem_details_response()` を返す場合、戻り値の型が異なる。どちらも `JSONResponse` のサブクラスまたはインスタンスなので、戻り値型は `JSONResponse` で統一できる。
+
+```python
+@app.get("/notes/{note_id}", response_model=NoteResponse)
+def get_note(note_id: int) -> JSONResponse:
+    if note_id not in _notes:
+        return problem_details_response("not-found", "Not Found", 404, "Note not found.")
+    return JSONResponse({"note_id": note_id, "title": "Hello"})
+```
+
+---
+
+## 4. response: Response パラメーターと JSONResponse の非互換
+
+FastAPI で `response: Response` パラメーターを使ってヘッダーを追加するパターンと、`JSONResponse` を直接返すパターンは **混在できない**。
+
+```python
+# ❌ response: Response を使ってヘッダーを追加しても JSONResponse には反映されない
+@app.get("/items/{item_id}")
+def get_item(item_id: int, response: Response) -> JSONResponse:
+    response.headers["X-Custom"] = "value"  # 効かない
+    return JSONResponse({"item_id": item_id})
+
+# ✅ JSONResponse に直接ヘッダーを渡す
+@app.get("/items/{item_id}")
+def get_item(item_id: int) -> JSONResponse:
+    return JSONResponse({"item_id": item_id}, headers={"X-Custom": "value"})
+```
+
+`response: Response` パラメーターは、FastAPI がレスポンスオブジェクトを自動生成する場合（`dict` 返却）にのみ有効。
+
+---
+
+## 5. 204 No Content と response_model
+
+`204 No Content` のエンドポイントに `response_model` を指定すると FastAPI がアサーションエラーになる。
+
+```python
+# ❌ 204 に response_model は指定できない
+@app.delete("/notes/{note_id}", status_code=204, response_model=SomeModel)
+def delete_note(note_id: int) -> None: ...
+
+# ✅ response_model を省略する
+@app.delete("/notes/{note_id}", status_code=204)
+def delete_note(note_id: int) -> None: ...
+```

--- a/docs/how-to/streaming.md
+++ b/docs/how-to/streaming.md
@@ -1,0 +1,135 @@
+# How-to: ストリーミングレスポンス
+
+`StreamingResponse` を使った SSE・NDJSON・CSV のストリーミングパターンを説明する。
+
+---
+
+## 1. Server-Sent Events (SSE)
+
+リアルタイム通知や進捗更新に使う。
+
+```python
+import asyncio
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+app = FastAPI()
+
+async def sse_generator(topic: str) -> AsyncIterator[str]:
+    for i in range(5):
+        yield f"data: {{'topic': '{topic}', 'count': {i}}}\n\n"
+        await asyncio.sleep(1)
+    yield "data: {\"done\": true}\n\n"
+
+@app.get("/events/{topic}")
+async def stream_events(topic: str) -> StreamingResponse:
+    return StreamingResponse(
+        sse_generator(topic),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # nginx プロキシのバッファリングを無効化
+        },
+    )
+```
+
+SSE フォーマット: 各メッセージは `data: ...\n\n`（改行2つ）で終わる。
+
+---
+
+## 2. NDJSON (Newline Delimited JSON)
+
+大量データのストリーミング転送に使う。
+
+```python
+import json
+from collections.abc import AsyncIterator
+
+async def ndjson_generator(items: list[dict[str, object]]) -> AsyncIterator[str]:
+    for item in items:
+        yield json.dumps(item, ensure_ascii=False) + "\n"
+
+@app.get("/export/items")
+async def export_items() -> StreamingResponse:
+    items = fetch_all_items()
+    return StreamingResponse(
+        ndjson_generator(items),
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": "attachment; filename=items.ndjson"},
+    )
+```
+
+---
+
+## 3. CSV ストリーミング
+
+```python
+import csv
+import io
+from collections.abc import Iterator
+
+def csv_generator(rows: list[dict[str, object]]) -> Iterator[str]:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=["id", "name", "email"])
+    writer.writeheader()
+    yield buf.getvalue()
+    buf.seek(0)
+    buf.truncate()
+
+    for row in rows:
+        writer.writerow(row)
+        yield buf.getvalue()
+        buf.seek(0)
+        buf.truncate()
+
+@app.get("/export/users.csv")
+def export_users_csv() -> StreamingResponse:
+    rows = fetch_all_users()
+    return StreamingResponse(
+        csv_generator(rows),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=users.csv"},
+    )
+```
+
+---
+
+## 4. `response_model` は使えない
+
+`StreamingResponse` は `response_model` パラメーターと互換がない。OpenAPI スキーマに含まれるが、バリデーションは行われない。
+
+```python
+# ❌ StreamingResponse に response_model は指定しない
+@app.get("/stream", response_model=SomeModel)
+def stream() -> StreamingResponse: ...
+
+# ✅ response_model は省略
+@app.get("/stream")
+def stream() -> StreamingResponse: ...
+```
+
+---
+
+## 5. ミドルウェアとの共存
+
+nene2 の `RequestIdMiddleware`・`SecurityHeadersMiddleware` は `StreamingResponse` にも適用される。ストリーミング中でもレスポンスヘッダーに `X-Request-Id` が付く。
+
+---
+
+## 6. テスト
+
+```python
+def test_sse_stream() -> None:
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with client.stream("GET", "/events/test") as r:
+            assert r.status_code == 200
+            assert "text/event-stream" in r.headers["content-type"]
+            lines = []
+            for line in r.iter_lines():
+                lines.append(line)
+                if len(lines) >= 3:
+                    break
+            assert any("data:" in line for line in lines)
+```

--- a/docs/how-to/validation.md
+++ b/docs/how-to/validation.md
@@ -88,7 +88,41 @@ ValidationError("items.0.quantity", "1 以上を入力してください", Valid
 
 ---
 
-## 5. ErrorHandlerMiddleware との連携
+## 5. @model_validator エラーの field は "request" になる
+
+Pydantic の `@model_validator(mode="after")` で `raise ValueError(...)` すると、`loc` が空タプルになる。nene2 の `ValidationException` 変換ではこれを `field: "request"` に変換する。
+
+```python
+class RegisterBody(BaseModel):
+    password: str
+    password_confirm: str
+
+    @model_validator(mode="after")
+    def passwords_match(self) -> Self:
+        if self.password != self.password_confirm:
+            raise ValueError("Passwords do not match")
+        return self
+```
+
+レスポンス例（422）:
+
+```json
+{
+  "errors": [
+    {
+      "field": "request",
+      "message": "Value error, Passwords do not match",
+      "code": "value_error"
+    }
+  ]
+}
+```
+
+フロントエンドでは `field: "request"` をフォーム全体に対するエラーとして扱い、エラーメッセージに関係するフィールド名を文言に含める。
+
+---
+
+## 6. ErrorHandlerMiddleware との連携
 
 `nene2.middleware.ErrorHandlerMiddleware` をアプリに追加すると、
 `ValidationException` が自動で 422 Problem Details レスポンスに変換される。


### PR DESCRIPTION
## Summary

FT ループで蓄積した how-to ドキュメント不足 Issue (#324〜#380) を一括対応。

### 新規ファイル
- `docs/how-to/response-patterns.md` — JSONResponse+response_model、Domain/Pydantic 二重定義、204/response:Response 注意点
- `docs/how-to/lifespan-and-app-state.md` — lifespan パターン、app.state 型安全アクセス、TestClient with ブロック
- `docs/how-to/domain-events.md` — EventBus + BackgroundTasks パターン
- `docs/how-to/cors.md` — cors_allowed_origins 設定、credentials、テスト
- `docs/how-to/background-tasks.md` — UseCase 分離パターン、TestClient 同期実行挙動
- `docs/how-to/file-upload.md` — Content-Type 検証、マジックバイト、max_request_bytes
- `docs/how-to/streaming.md` — SSE・NDJSON・CSV ストリーミング

### 既存ファイル追記
- `docs/how-to/validation.md` — @model_validator エラーが field:"request" になる挙動
- `docs/how-to/async-use-case.md` — 同期 DB ブロッキング問題と run_in_threadpool

Closes #324, #347, #351, #362, #363, #364, #366, #367, #370, #374, #376, #378, #380

## Test plan
- [ ] CI pass (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)