### PR TITLE
feat: nene2.cache — TtlCache ユーティリティ追加 (v1.8.33)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-100.md
+++ b/docs/field-trials/2026-05-field-trial-100.md
@@ -1,0 +1,62 @@
+# Field Trial 100: In-memory TTL レスポンスキャッシュ
+
+## テーマ
+
+重い処理の結果を TTL 付きインメモリキャッシュに格納し、重複リクエストにキャッシュから応答するパターンを nene2 上で実装する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft100-response-cache/` に以下を実装:
+
+- `TtlCache` データクラス（TTL 付き辞書）
+- FastAPI lifespan でキャッシュを初期化・破棄
+- `Depends(get_cache)` でハンドラーに注入
+- キャッシュヒット/ミス判定、TTL 失効テスト
+
+## テスト結果
+
+全 7 テスト通過。
+
+## Friction Points
+
+### FP1: nene2 に TTL キャッシュユーティリティがない
+
+**状況**: キャッシュは Web API の基本パターンだが、nene2 に `TtlCache` のようなユーティリティが存在しない。`TtlCache` を毎回自前実装する必要がある。
+
+**影響**: 開発者がスレッドセーフでないキャッシュを実装してしまうリスク。また asyncio 環境での並行アクセスの考慮が漏れやすい（Python GIL により dict 操作自体はアトミックだが、get-then-set パターンは競合する）。
+
+**期待する API**:
+```python
+from nene2.cache import TtlCache
+
+cache = TtlCache(ttl_seconds=60.0)
+cache.set("key", value)
+value = cache.get("key")  # None if expired
+```
+
+### FP2: lifespan + グローバル変数パターンに型エラーが出る
+
+**状況**: キャッシュを lifespan で初期化してグローバル変数に格納するパターンで、`async def lifespan(app: FastAPI)` の型注釈に `type: ignore[type-arg]` が必要。
+
+```python
+_cache: TtlCache | None = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # type: ignore[type-arg] が必要
+    global _cache
+    _cache = TtlCache(ttl_seconds=60.0)
+    yield
+```
+
+`app.state` を使うパターンの方がよりクリーンだが、`app.state` の型付けも `app.state.cache` のアクセスで `Any` になる。
+
+### FP3: `app.state` でのキャッシュ管理がドキュメント化されていない
+
+**状況**: `lifespan-and-app-state.md` では `app.state.db` の例はあるが、キャッシュを `app.state` に格納するパターン（`request.app.state.cache`）の説明がない。
+
+**影響**: グローバル変数を使う開発者が多く、テスト時のリセットが困難になる。
+
+## まとめ
+
+キャッシュユーティリティ追加は中程度の価値あり（FP1）。FP2・FP3 はドキュメント摩擦。
+今回は FP1 を `nene2.cache` モジュールとして実装し、Issue を起票する。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.32"
+version = "1.8.33"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/cache/__init__.py
+++ b/src/nene2/cache/__init__.py
@@ -1,0 +1,5 @@
+"""In-memory TTL キャッシュユーティリティ."""
+
+from .ttl import TtlCache
+
+__all__ = ["TtlCache"]

--- a/src/nene2/cache/ttl.py
+++ b/src/nene2/cache/ttl.py
@@ -1,0 +1,57 @@
+"""TTL 付きインメモリキャッシュ."""
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Entry[V]:
+    value: V
+    expires_at: float
+
+
+@dataclass
+class TtlCache[V]:
+    """TTL 付きインメモリキャッシュ。
+
+    asyncio コンテキストでの利用を想定。Python GIL により dict 操作は
+    アトミックで安全だが、get-then-set のような複合操作は排他しない。
+
+    Args:
+        ttl_seconds: キャッシュエントリの生存時間（秒）。
+
+    Example:
+        cache: TtlCache[dict[str, object]] = TtlCache(ttl_seconds=60.0)
+        cache.set("key", {"data": 42})
+        value = cache.get("key")
+    """
+
+    ttl_seconds: float
+    _store: dict[str, _Entry[V]] = field(default_factory=dict, init=False, repr=False)
+
+    def get(self, key: str) -> V | None:
+        """キーに対応する値を返す。TTL 切れの場合は None を返してエントリを削除する。"""
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        if time.monotonic() > entry.expires_at:
+            del self._store[key]
+            return None
+        return entry.value
+
+    def set(self, key: str, value: V) -> None:
+        """キーと値を TTL 付きで格納する。"""
+        self._store[key] = _Entry(value=value, expires_at=time.monotonic() + self.ttl_seconds)
+
+    def delete(self, key: str) -> None:
+        """キーに対応するエントリを削除する。存在しなくても例外は発生しない。"""
+        self._store.pop(key, None)
+
+    def clear(self) -> None:
+        """すべてのエントリを削除する。"""
+        self._store.clear()
+
+    def size(self) -> int:
+        """TTL 切れを除いた有効なエントリ数を返す。"""
+        now = time.monotonic()
+        return sum(1 for e in self._store.values() if e.expires_at > now)

--- a/tests/nene2/cache/test_ttl.py
+++ b/tests/nene2/cache/test_ttl.py
@@ -1,0 +1,76 @@
+"""Tests for nene2.cache.TtlCache."""
+
+import time
+
+import pytest
+
+from nene2.cache import TtlCache
+
+
+def test_set_and_get_returns_value() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.set("key", {"data": 42})
+    assert cache.get("key") == {"data": 42}
+
+
+def test_get_missing_key_returns_none() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    assert cache.get("nonexistent") is None
+
+
+def test_expired_entry_returns_none() -> None:
+    cache = TtlCache(ttl_seconds=0.01)
+    cache.set("key", "value")
+    time.sleep(0.02)
+    assert cache.get("key") is None
+
+
+def test_expired_entry_is_removed_from_store() -> None:
+    cache = TtlCache(ttl_seconds=0.01)
+    cache.set("key", "value")
+    time.sleep(0.02)
+    cache.get("key")  # TTL 切れでエントリ削除
+    assert cache.size() == 0
+
+
+def test_delete_removes_entry() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.set("key", "value")
+    cache.delete("key")
+    assert cache.get("key") is None
+
+
+def test_delete_missing_key_does_not_raise() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.delete("nonexistent")  # should not raise
+
+
+def test_clear_removes_all_entries() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.clear()
+    assert cache.size() == 0
+
+
+def test_size_excludes_expired_entries() -> None:
+    cache = TtlCache(ttl_seconds=0.01)
+    cache.set("expired", "value")
+    time.sleep(0.02)
+    cache.set("fresh", "value")
+    assert cache.size() == 1
+
+
+def test_overwrite_resets_ttl() -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.set("key", "old")
+    cache.set("key", "new")
+    assert cache.get("key") == "new"
+
+
+@pytest.mark.parametrize("value", [None, 0, "", [], {}, False])
+def test_falsy_values_are_stored_correctly(value: object) -> None:
+    cache = TtlCache(ttl_seconds=60.0)
+    cache.set("key", value)
+    assert cache.get("key") == value
+    assert cache.size() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.32"
+version = "1.8.33"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 概要

FT100 (In-memory TTL レスポンスキャッシュ) で発見した摩擦を解消。

`nene2.cache` モジュールを新設し、TTL 付きインメモリキャッシュを追加。

## 変更内容

- `src/nene2/cache/__init__.py` — 新規モジュール
- `src/nene2/cache/ttl.py` — `TtlCache[V]` ジェネリック実装
- `tests/nene2/cache/test_ttl.py` — 15 テスト
- `docs/field-trials/2026-05-field-trial-100.md` — FT100 レポート
- `pyproject.toml` + `uv.lock` — v1.8.33

## API

```python
from nene2.cache import TtlCache

cache: TtlCache[dict[str, object]] = TtlCache(ttl_seconds=60.0)
cache.set("item:1", {"id": 1, "name": "Alice"})
value = cache.get("item:1")  # None if expired
cache.delete("item:1")
cache.clear()
n = cache.size()  # 有効エントリ数
```

- `time.monotonic()` ベースの TTL（単調増加で NTP 調整の影響なし）
- ジェネリック型パラメーター `[V]` で型安全

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)