### PR TITLE
docs: Depends Annotated スタイル how-to ガイド追加 (FT101)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-101.md
+++ b/docs/field-trials/2026-05-field-trial-101.md
@@ -1,0 +1,59 @@
+# Field Trial 101: Query Parameter Filter/Sort パターン
+
+## テーマ
+
+`?status=published&sort=views&order=desc&tag=fastapi` のような複数フィルター + ソートのクエリパラメーターを型安全に扱うパターンを nene2 上で実装する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft101-query-filter/` に以下を実装:
+
+- `ArticleFilter` dataclass に `StrEnum` で列挙型フィルター
+- `get_article_filter()` ファクトリ関数で `Depends()` に接続
+- `PaginationQueryParser` と組み合わせてページネーション
+- 11 テスト通過
+
+## テスト結果
+
+全 11 テスト通過（修正後）。
+
+## Friction Points
+
+### FP1: `PaginationQueryParser.as_depends()` が存在しない（ドキュメントとの乖離）
+
+**状況**: 他のパーサー系クラスで `as_depends()` ファクトリパターンを使うケースがあり（FT83 など）、`PaginationQueryParser.as_depends()` を試みたが `AttributeError`。
+
+正しい使い方は:
+```python
+# ✅ Annotated スタイル
+pagination: Annotated[PaginationQueryParser, Depends()]
+
+# ❌ as_depends() は存在しない
+pagination: PaginationQueryParser = Depends(PaginationQueryParser.as_depends())
+```
+
+**影響**: `Depends()` の使い方が複数あるため混乱しやすい。how-to ガイドに明記が必要。
+
+### FP2: `Depends()` スタイルとデフォルト値の混在でシンタックスエラー
+
+**状況**: 複数の `Depends()` パラメーターを持つハンドラーで、`= Depends(...)` スタイルと `Annotated[T, Depends()]` スタイルを混在させると `SyntaxError: parameter without a default follows parameter with a default` が出る。
+
+```python
+# ❌ SyntaxError
+def list_articles(
+    filter_: ArticleFilter = Depends(get_article_filter),  # デフォルト値あり
+    pagination: Annotated[PaginationQueryParser, Depends()],  # デフォルト値なし
+) -> JSONResponse: ...
+
+# ✅ Annotated スタイルに統一
+def list_articles(
+    filter_: Annotated[ArticleFilter, Depends(get_article_filter)],
+    pagination: Annotated[PaginationQueryParser, Depends()],
+) -> JSONResponse: ...
+```
+
+**影響**: エラーメッセージが直感的でなく、原因がわかりにくい。
+
+## まとめ
+
+摩擦の原因はドキュメント不足。FP1・FP2 を how-to ガイドに追記する Issue を起票する。コード修正は不要。

--- a/docs/how-to/dependency-injection.md
+++ b/docs/how-to/dependency-injection.md
@@ -1,0 +1,136 @@
+# How-to: FastAPI Depends パターン
+
+FastAPI の `Depends()` の使い方と、`Annotated` スタイルへの統一パターンを説明する。
+
+---
+
+## 1. 2 つの Depends スタイル
+
+FastAPI には `Depends()` の書き方が 2 通りある。
+
+```python
+# スタイル A: = Depends(...) （デフォルト値スタイル）
+def handler(
+    use_case: FetchUserUseCase = Depends(get_fetch_user_use_case),
+) -> JSONResponse: ...
+
+# スタイル B: Annotated[T, Depends(...)] （Annotated スタイル）
+def handler(
+    use_case: Annotated[FetchUserUseCase, Depends(get_fetch_user_use_case)],
+) -> JSONResponse: ...
+```
+
+**推奨: `Annotated` スタイル（スタイル B）に統一する**
+
+---
+
+## 2. スタイル混在で起きる SyntaxError
+
+`= Depends(...)` と `Annotated[T, Depends()]` を同じ関数に混在させると **SyntaxError** が発生する。
+
+```python
+# ❌ SyntaxError: parameter without a default follows parameter with a default
+def list_articles(
+    filter_: ArticleFilter = Depends(get_filter),   # デフォルト値あり
+    pagination: Annotated[PaginationQueryParser, Depends()],  # デフォルト値なし
+) -> JSONResponse: ...
+
+# ✅ Annotated スタイルに統一
+def list_articles(
+    filter_: Annotated[ArticleFilter, Depends(get_filter)],
+    pagination: Annotated[PaginationQueryParser, Depends()],
+) -> JSONResponse: ...
+```
+
+Python の仕様として、デフォルト値を持つ引数の後にデフォルト値なしの引数は置けない。
+`Annotated[T, Depends()]` はデフォルト値を持たないため、`= Depends(...)` の後には書けない。
+
+---
+
+## 3. PaginationQueryParser の正しい使い方
+
+`PaginationQueryParser` は `Annotated[T, Depends()]` で使う。`as_depends()` は存在しない。
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from nene2.http import PaginationQueryParser
+
+# ✅ 正しい
+def list_items(
+    pagination: Annotated[PaginationQueryParser, Depends()],
+) -> JSONResponse:
+    result = use_case.execute(pagination.limit, pagination.offset)
+    ...
+
+# ❌ as_depends() は存在しない
+def list_items(
+    pagination: PaginationQueryParser = Depends(PaginationQueryParser.as_depends()),
+) -> JSONResponse: ...
+```
+
+---
+
+## 4. カスタムフィルター + ページネーション
+
+複数の `Depends()` パラメーターを組み合わせる場合はすべて `Annotated` スタイルで統一する。
+
+```python
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Query
+from fastapi.responses import JSONResponse
+
+from nene2.http import PaginationQueryParser
+
+
+class Status(StrEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+@dataclass(frozen=True, slots=True)
+class ItemFilter:
+    status: Status | None
+    tag: str | None
+
+
+def get_item_filter(
+    status: Annotated[Status | None, Query()] = None,
+    tag: Annotated[str | None, Query(max_length=50)] = None,
+) -> ItemFilter:
+    return ItemFilter(status=status, tag=tag)
+
+
+@app.get("/items")
+def list_items(
+    filter_: Annotated[ItemFilter, Depends(get_item_filter)],
+    pagination: Annotated[PaginationQueryParser, Depends()],
+) -> JSONResponse:
+    # フィルター: filter_.status, filter_.tag
+    # ページネーション: pagination.limit, pagination.offset
+    ...
+```
+
+---
+
+## 5. Depends でキャッシュを注入する
+
+`Annotated` スタイルで `app.state` のキャッシュを注入する例。
+
+```python
+from fastapi import Request
+from nene2.cache import TtlCache
+
+def get_cache(request: Request) -> TtlCache[dict[str, object]]:
+    return request.app.state.cache  # type: ignore[attr-defined]
+
+@app.get("/items/{item_id}")
+def get_item(
+    item_id: int,
+    cache: Annotated[TtlCache[dict[str, object]], Depends(get_cache)],
+) -> JSONResponse:
+    ...
+```


### PR DESCRIPTION
Issue #414 対応。`dependency-injection.md` を新規作成。

- `= Depends(...)` vs `Annotated[T, Depends()]` スタイルの説明
- スタイル混在で発生する SyntaxError の解説
- `PaginationQueryParser` の正しい使い方（`as_depends()` は存在しない）
- カスタムフィルター + ページネーションの組み合わせパターン
- FT101 レポート追加

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)