### PR TITLE
docs: カスタム認証ミドルウェア + request.state パターン how-to 追加 (FT103)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-103.md
+++ b/docs/field-trials/2026-05-field-trial-103.md
@@ -1,0 +1,47 @@
+# Field Trial 103: カスタムミドルウェアで認証情報をリクエストスコープに格納
+
+## テーマ
+
+JWT ミドルウェアで検証後の認証情報（`AuthUser`）を `request.state` に格納し、ハンドラーで `Depends()` を通じて取得するパターンを検証する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft103-request-state-auth/` に以下を実装:
+
+- `JwtAuthMiddleware` — JWT を検証して `request.state.user` に `AuthUser` を格納
+- `get_current_user()` — `request.state.user` から `AuthUser` を取得する Depends ファクトリ
+- `require_admin()` — `admin` ロールチェック依存
+- `EXCLUDE_PATHS` で `/health` をスキップ
+
+## テスト結果
+
+全 7 テスト通過。`InsecureKeyLengthWarning` はテスト用の短いシークレットによるもの（想定内）。
+
+## Friction Points
+
+### FP1: `request.state.user` アクセスに `type: ignore[attr-defined]` が必要
+
+**状況**: `request.state` は `starlette.datastructures.State` で動的属性を持つ。ミドルウェアで `request.state.user = AuthUser(...)` と設定しても、Depends ファクトリで `request.state.user` を参照する際に mypy が `attr-defined` エラーを出す。
+
+```python
+def get_current_user(request: Request) -> AuthUser:
+    user: AuthUser = request.state.user  # type: ignore[attr-defined]  # reason: middleware で確実に設定済み
+    return user
+```
+
+これは `app.state` でも同様（FT100 で確認済み）。
+
+**影響**: 低。`type: ignore` + `reason` コメントで対処可能。
+
+### FP2: `BearerTokenMiddleware` のトークン文字列が `request.state` に格納されない
+
+**状況**: nene2 の `BearerTokenMiddleware` は JWT/API キーの検証後にトークン文字列を返す（`make_require_auth()` Depends 経由）が、検証済みのペイロードやユーザー情報を `request.state` に自動格納する機能がない。
+
+カスタム JWT ミドルウェアで対応したが、`BearerTokenMiddleware` + `request.state` の統合パターンがない。
+
+**影響**: 中。`BearerTokenMiddleware` を使いたいが `request.state` にユーザー情報を格納したい場合、自前ミドルウェアを書き直す必要がある。
+
+## まとめ
+
+FP1 は既知の Starlette 制約（low）。FP2 は nene2 の認証統合に関する中程度の摩擦。
+docs として「request.state を使った認証情報伝播パターン」を how-to に追加する。

--- a/docs/how-to/custom-auth-middleware.md
+++ b/docs/how-to/custom-auth-middleware.md
@@ -1,0 +1,141 @@
+# How-to: カスタム認証ミドルウェアと request.state
+
+カスタムミドルウェアで認証・認可情報を `request.state` に格納し、ハンドラーで `Depends()` を通じて取得するパターンを説明する。
+
+---
+
+## 1. AuthUser dataclass の定義
+
+認証済みユーザー情報を表す immutable dataclass を定義する。
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class AuthUser:
+    user_id: str
+    roles: list[str]
+```
+
+---
+
+## 2. JWT ミドルウェアで request.state に格納
+
+`BaseHTTPMiddleware` を継承してカスタム JWT 検証を実装し、`request.state.user` に `AuthUser` を格納する。
+
+```python
+import jwt
+from fastapi import FastAPI
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+SECRET = "your-32-char-or-longer-secret-key"
+
+class JwtAuthMiddleware(BaseHTTPMiddleware):
+    EXCLUDE_PATHS = {"/health", "/login"}
+
+    def __init__(self, app: ASGIApp, secret: str) -> None:
+        super().__init__(app)
+        self._secret = secret
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in self.EXCLUDE_PATHS:
+            return await call_next(request)
+
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+        token = auth[7:]
+        try:
+            payload = jwt.decode(token, self._secret, algorithms=["HS256"])
+            request.state.user = AuthUser(
+                user_id=payload["sub"],
+                roles=payload.get("roles", []),
+            )
+        except jwt.InvalidTokenError:
+            return JSONResponse({"error": "Invalid token"}, status_code=401)
+
+        return await call_next(request)
+
+app = FastAPI()
+app.add_middleware(JwtAuthMiddleware, secret=SECRET)
+```
+
+---
+
+## 3. Depends ファクトリで AuthUser を取得
+
+`request.state.user` から `AuthUser` を取得する Depends ファクトリを定義する。
+
+```python
+from fastapi import Request
+
+def get_current_user(request: Request) -> AuthUser:
+    user: AuthUser = request.state.user  # type: ignore[attr-defined]  # reason: JwtAuthMiddleware で確実に設定
+    return user
+```
+
+`type: ignore[attr-defined]` が必要な理由: `request.state` は `starlette.datastructures.State` で動的属性を持つため、mypy は `user` 属性を認識できない。ミドルウェアで設定済みであることが保証されているため安全。
+
+---
+
+## 4. ロールベースアクセス制御
+
+`require_admin()` のようなロール確認 Depends を定義して、エンドポイントに適用する。
+
+```python
+from typing import Annotated
+from fastapi import Depends, HTTPException
+
+def require_admin(user: Annotated[AuthUser, Depends(get_current_user)]) -> AuthUser:
+    if "admin" not in user.roles:
+        raise HTTPException(status_code=403, detail="Admin required")
+    return user
+
+@app.get("/admin/users")
+def admin_list_users(
+    user: Annotated[AuthUser, Depends(require_admin)],
+) -> JSONResponse:
+    return JSONResponse({"admin": user.user_id, "users": [...]})
+```
+
+---
+
+## 5. BearerTokenMiddleware との使い分け
+
+| パターン | 使い方 | `request.state` へ格納 |
+|---|---|---|
+| `BearerTokenMiddleware` + `make_require_auth()` | トークン文字列の検証・取得 | しない（Depends 経由） |
+| カスタム `JwtAuthMiddleware` | JWT ペイロード検証・AuthUser 構築 | する（`request.state.user`） |
+
+**カスタムミドルウェアが向いているケース**:
+- JWT のペイロード（ロール・クレーム）をハンドラーで使いたい
+- 認証結果をリクエストスコープ全体で共有したい
+
+**`BearerTokenMiddleware` が向いているケース**:
+- トークンの有効性チェックだけしたい
+- `TokenVerifierProtocol` で検証ロジックを差し替えたい
+
+---
+
+## 6. テストパターン
+
+```python
+import jwt
+from fastapi.testclient import TestClient
+
+SECRET = "your-32-char-or-longer-secret-key"
+
+def make_token(user_id: str, roles: list[str]) -> str:
+    return jwt.encode({"sub": user_id, "roles": roles}, SECRET, algorithm="HS256")
+
+def test_profile_with_valid_token() -> None:
+    with TestClient(app) as client:
+        token = make_token("alice", ["user"])
+        r = client.get("/profile", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+        assert r.json()["user_id"] == "alice"
+```


### PR DESCRIPTION
Issue #417 対応。`custom-auth-middleware.md` を新規作成。

- `JwtAuthMiddleware` で `request.state.user` に `AuthUser` を格納するパターン
- `get_current_user()` Depends ファクトリの実装例
- `require_admin()` ロールチェック
- `BearerTokenMiddleware` との使い分け
- テストパターン
- FT103 レポート追加

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)