### PR TITLE
docs: streaming how-to に TestClient.iter_text() パターン追記 (FT104)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-104.md
+++ b/docs/field-trials/2026-05-field-trial-104.md
@@ -1,0 +1,48 @@
+# Field Trial 104: AsyncIterator を返す UseCase + StreamingResponse
+
+## テーマ
+
+UseCase が `AsyncIterator` を返し、FastAPI の `StreamingResponse` でストリーミングする本格的なパターンを検証する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft104-streaming-usecase/` に以下を実装:
+
+- `StreamLogsUseCase` — `AsyncIterator[LogEntry]` を返す UseCase
+- `ExportCsvUseCase` — CSV 行を `AsyncIterator[str]` で返す UseCase
+- NDJSON / SSE / CSV の 3 形式にストリーミング変換
+- 6 テスト通過
+
+## テスト結果
+
+全 6 テスト通過（修正後）。
+
+## Friction Points
+
+### FP1: `TestClient.stream()` 内で `r.text` が使えない
+
+**状況**: `with client.stream("GET", "/export/users.csv") as r:` コンテキスト内で `r.text` にアクセスすると `httpx.ResponseNotRead` が発生する。
+
+```python
+# ❌ ResponseNotRead
+with client.stream("GET", "/export/csv") as r:
+    content = r.text  # エラー!
+
+# ✅ iter_text() でチャンク収集
+with client.stream("GET", "/export/csv") as r:
+    content = "".join(r.iter_text())
+```
+
+**影響**: ストリーミングレスポンスのテストで直感に反するエラーが出る。`streaming.md` How-to に `iter_text()` パターンを追記する必要がある。
+
+### FP2: `AsyncUseCaseProtocol` は `AsyncIterator` を返す UseCase に対応していない
+
+**状況**: `AsyncUseCaseProtocol` は `async def execute(self, input_: I) -> O` を定義しており、`O = AsyncIterator[T]` として使うことは技術的には可能だが、`O` 型が `AsyncIterator` であることを表現するのが難しい。
+
+現在の実装では `AsyncUseCaseProtocol` を使わず、独立した UseCase クラスとして実装した。
+
+**影響**: 低。ストリーミング UseCase は専用の Protocol を定義するか、型注釈なしで書くのが現実的。
+
+## まとめ
+
+FP1 をドキュメント修正で対応。FP2 は将来の検討事項として記録。

--- a/docs/how-to/streaming.md
+++ b/docs/how-to/streaming.md
@@ -120,6 +120,9 @@ nene2 の `RequestIdMiddleware`・`SecurityHeadersMiddleware` は `StreamingResp
 
 ## 6. テスト
 
+`client.stream()` コンテキスト内では `r.text` / `r.content` は使えない（`ResponseNotRead`）。
+`r.iter_lines()` / `r.iter_text()` / `r.iter_bytes()` でチャンクを収集する。
+
 ```python
 def test_sse_stream() -> None:
     with TestClient(app, raise_server_exceptions=False) as client:
@@ -132,4 +135,14 @@ def test_sse_stream() -> None:
                 if len(lines) >= 3:
                     break
             assert any("data:" in line for line in lines)
+
+def test_csv_stream() -> None:
+    with TestClient(app) as client:
+        with client.stream("GET", "/export/users.csv") as r:
+            assert r.status_code == 200
+            # ✅ iter_text() でテキストを収集
+            content = "".join(r.iter_text())
+            # ❌ r.text は ResponseNotRead になる
+        lines = [l for l in content.splitlines() if l]
+        assert lines[0] == "id,name,email"
 ```


### PR DESCRIPTION
FT104 (AsyncIterator UseCase + StreamingResponse) で発見した摩擦を解消。

`streaming.md` に `r.text` が使えない理由と `iter_text()` パターンを追加。
FT104 レポートも追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)