### PR TITLE
docs: model_dump(mode="json") の注意点と computed_field FT108 を記録

### DIFF
--- a/docs/field-trials/2026-05-field-trial-108.md
+++ b/docs/field-trials/2026-05-field-trial-108.md
@@ -1,0 +1,46 @@
+# Field Trial 108: Pydantic computed_field と property パターン
+
+## テーマ
+
+Pydantic v2 の `@computed_field` + `@property` を使って、ストアドフィールドから計算されるプロパティを
+OpenAPI スキーマに自動的に含めるパターンを検証する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft108-computed-field/` に以下を実装:
+
+- `ProductResponse` — `price_dollars`, `is_in_stock`, `display_name` の computed fields
+- `OrderLineResponse` — ネストした computed fields (`line_total_cents`, `line_total_dollars`)
+- `/order-preview` エンドポイントで `JSONResponse(line.model_dump(mode="json"))` パターン確認
+- 6 テスト通過
+
+## テスト結果
+
+全 6 テスト通過。
+
+## Friction Points
+
+### FP1: `model_dump()` が datetime を Python オブジェクトのまま返す → `JSONResponse` で 500 エラー
+
+**状況**: `OrderLineResponse` のネストモデルには `created_at: datetime` フィールドがある。
+`JSONResponse(line.model_dump())` を使うと、`json.dumps` が `datetime` を直列化できずに
+`TypeError: Object of type datetime is not JSON serializable` で 500 エラーになる。
+
+```python
+# ❌ model_dump() は datetime をそのまま返す → JSONResponse でエラー
+return JSONResponse(line.model_dump())
+
+# ✅ mode="json" を指定すると datetime を ISO 8601 文字列に変換する
+return JSONResponse(line.model_dump(mode="json"))
+```
+
+**影響**: 大。`response_model=` を使う通常のルートは FastAPI が自動変換するため問題ないが、
+`JSONResponse` を直接返すルート（207 Multi-Status, /order-preview など）でこのパターンを
+使い忘れると本番で 500 エラーになる。
+
+**代替案**: `jsonable_encoder(line.model_dump())` でも変換できるが、`mode="json"` の方が Pydantic 標準。
+
+## まとめ
+
+`@computed_field` + `@property` は摩擦ゼロで OpenAPI スキーマに含められる優れたパターン。
+FP1 は `JSONResponse` を直接使う場合の注意点として how-to に追記する。

--- a/docs/how-to/response-patterns.md
+++ b/docs/how-to/response-patterns.md
@@ -95,7 +95,36 @@ def get_item(item_id: int) -> JSONResponse:
 
 ---
 
-## 5. 204 No Content と response_model
+## 5. JSONResponse に model_dump() を渡す場合は mode="json" を使う
+
+`JSONResponse` に直接 `model_dump()` を渡すとき、`datetime` などの Python オブジェクトは
+`json.dumps` でシリアライズできず 500 エラーになる。`mode="json"` を指定すると
+Pydantic が JSON 互換な型に変換する。
+
+```python
+from pydantic import BaseModel
+from datetime import datetime
+
+class OrderLine(BaseModel):
+    created_at: datetime
+    quantity: int
+
+line = OrderLine(created_at=datetime(2026, 1, 1), quantity=3)
+
+# ❌ TypeError: Object of type datetime is not JSON serializable
+return JSONResponse(line.model_dump())
+
+# ✅ mode="json" で datetime → ISO 8601 文字列に変換される
+return JSONResponse(line.model_dump(mode="json"))
+```
+
+**影響が出る場面**: `response_model=` を使う通常ルートは FastAPI が自動変換するため問題ない。
+`JSONResponse` を直接返すルート（207 Multi-Status、カスタムレスポンス、ネストモデル含む `/preview` など）
+で注意が必要。
+
+---
+
+## 6. 204 No Content と response_model
 
 `204 No Content` のエンドポイントに `response_model` を指定すると FastAPI がアサーションエラーになる。
 


### PR DESCRIPTION
## Summary

- `response-patterns.md` に `model_dump(mode="json")` が必要な場合のセクションを追加（セクション 5）
- FT108（Pydantic `@computed_field` + `property` パターン）フィールドトライアルレポートを追加

## 背景

FT108 で `JSONResponse(line.model_dump())` を使ったところ `datetime` フィールドが
JSON シリアライズできずに 500 エラーになることを確認。`mode="json"` を指定すれば回避できる。

Closes #424

## Test plan

- [ ] CI (pytest / mypy / ruff / pip-audit) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)