### PR TITLE
docs: FT109 API バージョニングの how-to とレポートを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-109.md
+++ b/docs/field-trials/2026-05-field-trial-109.md
@@ -1,0 +1,53 @@
+# Field Trial 109: API バージョニング（v1/v2 ルーティング）
+
+## テーマ
+
+FastAPI の `APIRouter` を使って `/v1` と `/v2` でエンドポイントを分離するパターンを検証する。
+- フィールド名の変更（`email` → `contact_email`）
+- フィールドの追加（`age` を v2 で追加）
+- `full_name` から `first_name`/`last_name` への分割
+- OpenAPI スキーマが両バージョンを正確に反映するか
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft109-api-versioning/` に以下を実装:
+
+- ドメイン `User` dataclass（バージョン非依存）
+- `UserResponseV1` — `full_name`, `email`
+- `UserResponseV2` — `first_name`, `last_name`, `contact_email`, `age`
+- `v1_router = APIRouter(prefix="/v1", tags=["v1"])`
+- `v2_router = APIRouter(prefix="/v2", tags=["v2"])`
+- 9 テスト通過
+
+## テスト結果
+
+全 9 テスト一発通過。摩擦ゼロ。
+
+## Friction Points
+
+なし。`APIRouter(prefix="/v1")` でルーターを分離し `app.include_router()` で登録するだけで
+バージョン分離が完成する。OpenAPI スキーマも `UserResponseV1` / `UserResponseV2` を
+個別に定義することで両バージョンのスキーマが正確に生成される。
+
+## 観察
+
+### O1: バージョン間の共有ロジックはドメイン層に置く
+
+`find_user()` などのクエリ関数はバージョン非依存のドメイン層に置き、
+各バージョンのハンドラーから呼ぶ設計が自然に機能した。
+`from_domain()` クラスメソッドで変換することでドメインと HTTP を分離できた。
+
+### O2: OpenAPI タグでバージョンを整理できる
+
+`tags=["v1"]` / `tags=["v2"]` を `APIRouter` に指定すると、
+Swagger UI でバージョンごとにグループ化されて見やすくなる。
+
+### O3: `APIRouter` prefix は重複しない
+
+`app.include_router(v1_router)` で登録すると `/v1/users` になる。
+ルーター内のパスに `/v1` を書く必要はない（二重にならない）。
+
+## まとめ
+
+FT109 は摩擦ゼロ確認。APIバージョニングは FastAPI の `APIRouter` + `prefix` で
+自然に実現できる。how-to ドキュメントに記録のみ。

--- a/docs/how-to/api-versioning.md
+++ b/docs/how-to/api-versioning.md
@@ -1,0 +1,92 @@
+# How-to: API バージョニング
+
+FastAPI の `APIRouter` + `prefix` でエンドポイントを `/v1`, `/v2` に分離するパターン。
+
+---
+
+## 基本構成
+
+```python
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+v1_router = APIRouter(prefix="/v1", tags=["v1"])
+v2_router = APIRouter(prefix="/v2", tags=["v2"])
+
+@v1_router.get("/users")
+def list_users_v1() -> list[UserResponseV1]:
+    ...
+
+@v2_router.get("/users")
+def list_users_v2() -> list[UserResponseV2]:
+    ...
+
+app.include_router(v1_router)
+app.include_router(v2_router)
+```
+
+`APIRouter` の `prefix` はルーター内のパスに **自動的に付加**される。
+ルーター内のパスに `/v1` を書く必要はない（二重にならない）。
+
+---
+
+## ドメイン層は共有、HTTP 層でバージョン差分を吸収
+
+バージョン間の共有ロジックはドメイン層に置き、各バージョンの Pydantic モデルで差分を表現する。
+
+```python
+# ドメイン層（バージョン非依存）
+@dataclass(frozen=True, slots=True)
+class User:
+    user_id: int
+    first_name: str
+    last_name: str
+    email: str
+    age: int
+
+# v1: full_name に結合
+class UserResponseV1(BaseModel):
+    user_id: int
+    full_name: str
+    email: str
+
+    @classmethod
+    def from_domain(cls, user: User) -> "UserResponseV1":
+        return cls(
+            user_id=user.user_id,
+            full_name=f"{user.first_name} {user.last_name}",
+            email=user.email,
+        )
+
+# v2: first_name/last_name を分離 + age を追加 + email → contact_email
+class UserResponseV2(BaseModel):
+    user_id: int
+    first_name: str
+    last_name: str
+    contact_email: str
+    age: int
+
+    @classmethod
+    def from_domain(cls, user: User) -> "UserResponseV2":
+        return cls(
+            user_id=user.user_id,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            contact_email=user.email,
+            age=user.age,
+        )
+```
+
+---
+
+## OpenAPI スキーマ
+
+`tags=["v1"]` / `tags=["v2"]` を `APIRouter` に指定すると Swagger UI でバージョンごとに
+グループ化される。スキーマには `UserResponseV1` / `UserResponseV2` が個別に定義される。
+
+---
+
+## 参照
+
+- FT109: `docs/field-trials/2026-05-field-trial-109.md`


### PR DESCRIPTION
## Summary

- `docs/how-to/api-versioning.md` を新規追加（`APIRouter` prefix バージョニングパターン）
- `docs/field-trials/2026-05-field-trial-109.md` を追加（FT109 摩擦ゼロ確認）

## Test plan

- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)