### PR TITLE
docs: FT110 ソフトデリートパターン how-to とレポートを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-110.md
+++ b/docs/field-trials/2026-05-field-trial-110.md
@@ -1,0 +1,66 @@
+# Field Trial 110: ソフトデリートパターン（論理削除）
+
+## テーマ
+
+`deleted_at: datetime | None` フィールドを使った論理削除パターンを検証する。
+- `DELETE /resources/{id}` が物理削除ではなく `deleted_at` をセットする
+- `GET /resources` / `GET /resources/{id}` が削除済みアイテムを除外する
+- DELETE は冪等（既に削除済みでも 204）
+- `deleted_at` を公開レスポンスに含めない（管理エンドポイントのみ）
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft110-soft-delete/` に以下を実装:
+
+- `Article` dataclass — `deleted_at: datetime | None = None`、`is_deleted` プロパティ
+- `dataclasses.replace()` で frozen dataclass を更新（`deleted_at` をセット）
+- `ArticleResponse` に `deleted_at` フィールドを含めない設計
+- 管理用 `/articles/{id}/deleted` エンドポイントで `deleted_at` を確認
+- 9 テスト通過
+
+## テスト結果
+
+全 9 テスト一発通過。摩擦ゼロ。
+
+## Friction Points
+
+なし。
+
+## 観察
+
+### O1: frozen dataclass の更新は dataclasses.replace() で簡潔に書ける
+
+```python
+from dataclasses import replace
+
+_articles[article_id] = replace(article, deleted_at=datetime.now(UTC))
+```
+
+`frozen=True` な dataclass でも `replace()` で新しいインスタンスを作成できる。
+イミュータブル設計を壊さずに更新できる。
+
+### O2: is_deleted プロパティでビジネスロジックをドメインに閉じ込める
+
+```python
+@property
+def is_deleted(self) -> bool:
+    return self.deleted_at is not None
+```
+
+クエリフィルタ（`a.is_deleted`）でリポジトリ層が `deleted_at is not None` を意識しなくてよい。
+
+### O3: DELETE は 204 + 冪等が REST ベストプラクティス
+
+既に削除済みのリソースへの DELETE も 204 を返すことで冪等性を保つ。
+存在しないリソースへの DELETE も同様。
+
+### O4: deleted_at をレスポンスモデルから除外するのは Pydantic の通常設計で簡単
+
+`ArticleResponse` に `deleted_at` フィールドを定義しなければ、自動的に除外される。
+`exclude=` や `model_config` の設定は不要。
+
+## まとめ
+
+FT110 は摩擦ゼロ。ソフトデリートは nene2 + Python dataclass で自然に実装できる。
+`dataclasses.replace()` / `is_deleted` プロパティ / Pydantic レスポンスフィルタリングの
+各パターンを how-to に記録する。

--- a/docs/how-to/soft-delete.md
+++ b/docs/how-to/soft-delete.md
@@ -1,0 +1,92 @@
+# How-to: ソフトデリート（論理削除）
+
+`deleted_at: datetime | None` フィールドで論理削除を実装するパターン。
+
+---
+
+## ドメイン Entity
+
+```python
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+@dataclass(frozen=True, slots=True)
+class Article:
+    article_id: int
+    title: str
+    deleted_at: datetime | None = None
+
+    @property
+    def is_deleted(self) -> bool:
+        return self.deleted_at is not None
+```
+
+`is_deleted` プロパティでビジネスロジックをドメインに閉じ込め、呼び出し側が `deleted_at is not None` を意識しないようにする。
+
+---
+
+## frozen dataclass の更新: dataclasses.replace()
+
+```python
+from dataclasses import replace
+
+article = replace(article, deleted_at=datetime.now(UTC))
+```
+
+`frozen=True` な dataclass は直接フィールドを変更できないが、`replace()` で新しいインスタンスを作れる。
+
+---
+
+## DELETE エンドポイント（冪等）
+
+```python
+@app.delete("/articles/{article_id}", status_code=204)
+def delete_article(article_id: int) -> None:
+    article = _store.get(article_id)
+    if article is None or article.is_deleted:
+        return  # 冪等: 既に削除済みや存在しない場合も 204
+    _store[article_id] = replace(article, deleted_at=datetime.now(UTC))
+```
+
+RFC 9110 に従い、DELETE は冪等にする。存在しないリソースや削除済みリソースへの DELETE も 204 を返す。
+
+---
+
+## 一覧・取得での除外
+
+```python
+def _active_articles() -> list[Article]:
+    return [a for a in _store.values() if not a.is_deleted]
+
+@app.get("/articles", response_model=list[ArticleResponse])
+def list_articles() -> list[ArticleResponse]:
+    return [ArticleResponse.from_domain(a) for a in _active_articles()]
+
+@app.get("/articles/{article_id}")
+def get_article(article_id: int) -> JSONResponse:
+    article = _store.get(article_id)
+    if article is None or article.is_deleted:
+        return problem_details_response("not-found", "Not Found", 404, ...)
+```
+
+---
+
+## deleted_at をレスポンスから除外する
+
+`ArticleResponse` に `deleted_at` フィールドを定義しないだけでよい。
+Pydantic は定義されていないフィールドをシリアライズしない。
+
+```python
+class ArticleResponse(BaseModel):
+    article_id: int
+    title: str
+    # deleted_at は含めない → 公開 API に論理削除の実装詳細が漏れない
+```
+
+管理用エンドポイントのみ `deleted_at` を返す設計が推奨される。
+
+---
+
+## 参照
+
+- FT110: `docs/field-trials/2026-05-field-trial-110.md`


### PR DESCRIPTION
## Summary

- `docs/how-to/soft-delete.md` を新規追加（`deleted_at` 論理削除パターン）
- `docs/field-trials/2026-05-field-trial-110.md` を追加（FT110 摩擦ゼロ確認）

## パターン要点

- `dataclasses.replace()` で frozen dataclass を更新
- `is_deleted` プロパティでドメインにビジネスロジックを閉じ込め
- DELETE は冪等（既に削除済みでも 204）
- `ArticleResponse` に `deleted_at` を含めないだけで公開 API から除外できる

## Test plan

- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)