### PR TITLE
docs: FT111 カーソルページネーション レポートと validation how-to 追記

### DIFF
--- a/docs/field-trials/2026-05-field-trial-111.md
+++ b/docs/field-trials/2026-05-field-trial-111.md
@@ -1,0 +1,53 @@
+# Field Trial 111: カーソルベースページネーション
+
+## テーマ
+
+ID ベースのカーソル（Base64 エンコード）で大規模データを安定的にページングするパターンを検証する。
+既存の `PaginationQueryParser`（オフセット型）との比較として実装する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft111-cursor-pagination/` に以下を実装:
+
+- `after` クエリパラメータ + `limit` でカーソルページネーション
+- `next_cursor` / `has_next` を含む `CursorPage` レスポンスモデル
+- Base64 URL-safe エンコードでカーソルを不透明にする
+- 100件のサンプルデータで重複なし検証
+- 7 テスト通過（修正後）
+
+## テスト結果
+
+全 7 テスト通過（1件修正後）。
+
+## Friction Points
+
+### FP1: 無効なカーソルで `binascii.Error` が捕捉されず 500 になる
+
+**状況**: `?after=invalidcursor!` のような無効な Base64 文字列を渡すと、
+`base64.urlsafe_b64decode()` が `binascii.Error` を raise する。
+これを捕捉しないと `ErrorHandlerMiddleware` が 500 として返す。
+
+```python
+# ❌ binascii.Error が uncaught → 500
+after_id = _decode_cursor(after)
+
+# ✅ try-except でカーソルデコードを保護する
+try:
+    after_id = _decode_cursor(after)
+except Exception:
+    return JSONResponse({"detail": "Invalid cursor"}, status_code=400)
+```
+
+**影響**: 中。入力バリデーションとして当然捕捉すべきだが、
+Pydantic の `Query()` では Base64 形式の検証はできない（文字列型のみ）。
+カーソルデコードは必ず try-except で保護する必要がある。
+
+**代替案**: `ValidationException` を raise して 422 にするパターンもあるが、
+不正なカーソルは「バリデーションエラー」ではなく「不正リクエスト」なので 400 が適切。
+
+## まとめ
+
+FP1 を how-to に追記。カーソルのデコードは必ず try-except で保護し 400 を返す。
+オフセットページネーションとの使い分け:
+- オフセット型: 件数が少ない、管理画面など「ページ番号」で飛びたい場合
+- カーソル型: 件数が多い、リアルタイムデータ、無限スクロールなど

--- a/docs/how-to/validation.md
+++ b/docs/how-to/validation.md
@@ -133,3 +133,27 @@ from nene2.middleware import ErrorHandlerMiddleware
 app = FastAPI()
 app.add_middleware(ErrorHandlerMiddleware)
 ```
+
+---
+
+## 7. 外部入力のデコード失敗を 400 で返す
+
+Pydantic の `Query()` / `Body()` では型変換に失敗すると 422 になるが、
+カーソル (Base64) やトークンなど「文字列として受け取ってから自前でデコードする」場合、
+デコード失敗の例外を捕捉しないと `ErrorHandlerMiddleware` が 500 として返す。
+
+```python
+from fastapi.responses import JSONResponse
+
+@app.get("/posts")
+def list_posts(after: str | None = Query(None)) -> JSONResponse:
+    if after is not None:
+        try:
+            cursor_id = _decode_cursor(after)  # base64.urlsafe_b64decode など
+        except Exception:
+            return JSONResponse({"detail": "Invalid cursor"}, status_code=400)
+        # 以降は cursor_id を使って処理
+```
+
+`binascii.Error` などのデコード失敗は `ValueError` / `Exception` でまとめて捕捉し、
+`400 Bad Request` を返すのが適切（ユーザー入力ミスであり、サーバーエラーではない）。


### PR DESCRIPTION
## Summary

- `docs/field-trials/2026-05-field-trial-111.md` を追加（FT111 カーソルページネーション）
- `docs/how-to/validation.md` にセクション 7 を追加: 外部入力のデコード失敗を 400 で返すパターン

## FP1

無効な Base64 カーソルで `binascii.Error` が捕捉されず 500 になる問題を確認。
`try-except` で保護して 400 を返すパターンをドキュメント化。

## Test plan

- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)