### PR TITLE
docs: FT115 structlog 構造化ログ how-to とレポートを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-115.md
+++ b/docs/field-trials/2026-05-field-trial-115.md
@@ -1,0 +1,91 @@
+# Field Trial 115: structlog 構造化ログ + リクエストコンテキスト伝播
+
+## テーマ
+
+`RequestLoggingMiddleware` + `RequestIdMiddleware` が structlog contextvars に自動バインドする `request_id` を、
+エンドポイント内のログ呼び出しに透過的に伝播させるパターンを検証する。
+また pytest の `caplog` フィクスチャで structlog 出力をキャプチャできるかを確認する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft115-structured-logging/` に以下を実装:
+
+- `RequestLoggingMiddleware` + `RequestIdMiddleware` を組み合わせたアプリ
+- `structlog.get_logger(__name__)` でエンドポイント内からログを発行
+- `get_request_id()` でリクエスト ID をレスポンスボディに含める
+- `configure_for_testing()` を呼んで pytest caplog と統合
+- 11 テスト通過（修正後）
+
+## テスト結果
+
+2 件修正後、全 11 テスト通過。
+
+## Friction Points
+
+### FP1: `X-Request-Id` は UUID v4 形式のみ転送される — 非 UUID 値は黙って置換される
+
+**状況**: テストで `X-Request-Id: test-req-001` を送信したところ、レスポンスに別の UUID が返ってきた。
+`RequestIdMiddleware` は UUID v4 形式のみ受け付け、それ以外は新規 UUID を生成する設計になっている。
+
+```python
+# ❌ 非 UUID 形式は無効化される
+client.post("/orders", headers={"X-Request-Id": "test-req-001"})
+# → レスポンスの X-Request-Id は新規生成 UUID になる
+
+# ✅ UUID v4 形式なら転送される
+valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+client.post("/orders", headers={"X-Request-Id": valid_uuid})
+# → レスポンスの X-Request-Id は "550e8400-e29b-41d4-a716-446655440000"
+```
+
+**影響**: 小。設計として正しい動作（ログインジェクション対策）だが、
+テストで任意文字列を X-Request-Id に指定しようとすると予期せず失敗する。
+
+**代替案**: UUID v4 形式のリクエスト ID を使うか、`uuid.uuid4()` で生成してからテスト内で指定する。
+
+## 観察
+
+### O1: `RequestLoggingMiddleware` が structlog contextvars に request_id を自動バインド
+
+```python
+structlog.contextvars.bind_contextvars(
+    request_id=request_id_var.get(),
+    method=request.method,
+    path=request.url.path,
+)
+```
+
+エンドポイント内で `logger.info("order.creating", item_id=body.item_id)` を呼ぶと、
+`request_id`, `method`, `path` が自動付与される。明示的な引数渡しは不要。
+
+### O2: `configure_for_testing()` で structlog を pytest caplog に接続できる
+
+```python
+# conftest.py または test ファイルの先頭
+from nene2.log import configure_for_testing
+configure_for_testing()
+
+def test_logs(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO):
+        client.post("/orders", json={"item_id": 2, "quantity": 5})
+    assert any("order.creating" in record.message for record in caplog.records)
+```
+
+`configure_for_testing()` は structlog を stdlib logging ブリッジ経由で出力するように設定し直す。
+これにより pytest の caplog フィクスチャが structlog の出力を記録できる。
+
+### O3: `WARNING` レベルのログも caplog で確認できる
+
+```python
+with caplog.at_level(logging.WARNING):
+    client.get("/orders/404")
+assert any("order.not_found" in record.message for record in caplog.records)
+```
+
+`logger.warning(...)` は caplog の `WARNING` レベルフィルターで確認できる。
+
+## まとめ
+
+FP1（UUID v4 バリデーション）を how-to に追記予定。
+structlog + contextvars の伝播はフレームワークが完全に自動化しており、
+エンドポイント側の実装は `structlog.get_logger(__name__)` の呼び出しのみで完結する。

--- a/docs/how-to/structured-logging.md
+++ b/docs/how-to/structured-logging.md
@@ -1,0 +1,81 @@
+# How-to: 構造化ログ（structlog）
+
+`nene2.log` と `RequestLoggingMiddleware` を使った structlog の設定と、
+リクエストコンテキストの伝播パターンを説明する。
+
+---
+
+## 1. アプリ起動時にログを設定する
+
+`setup_logging()` を `create_app()` の先頭で呼ぶ。
+
+```python
+from nene2.log import setup_logging
+from nene2.middleware import RequestIdMiddleware, RequestLoggingMiddleware
+
+setup_logging(app_env="production", log_level="INFO")
+
+app = FastAPI()
+app.add_middleware(ErrorHandlerMiddleware)
+app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(RequestIdMiddleware)
+```
+
+`app_env="local"` のときは色付きコンソール出力、それ以外は JSON ログになる。
+
+---
+
+## 2. エンドポイント内でログを発行する
+
+```python
+import structlog
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+@app.post("/orders")
+def create_order(body: OrderRequest) -> JSONResponse:
+    logger.info("order.creating", item_id=body.item_id)
+    # request_id, method, path は RequestLoggingMiddleware が自動付与
+    ...
+```
+
+`RequestLoggingMiddleware` がリクエスト開始時に `request_id`, `method`, `path` を
+`structlog.contextvars.bind_contextvars()` でバインドするため、
+エンドポイント内の全ログにこれらが自動付与される。
+
+---
+
+## 3. pytest で structlog ログをキャプチャする
+
+`configure_for_testing()` を test ファイルまたは `conftest.py` の先頭で呼ぶ。
+
+```python
+from nene2.log import configure_for_testing
+
+configure_for_testing()  # structlog を stdlib logging ブリッジ経由に切り替え
+
+def test_order_logs(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+    with caplog.at_level(logging.INFO):
+        client.post("/orders", json={"item_id": 1, "quantity": 1})
+    assert any("order.creating" in r.message for r in caplog.records)
+```
+
+---
+
+## 4. X-Request-Id は UUID v4 形式のみ転送される
+
+`RequestIdMiddleware` はクライアント提供の `X-Request-Id` を UUID v4 形式のみ受け付ける。
+非 UUID 値（`"test-id-001"` など）は黙って新規 UUID に置き換えられる。
+
+```python
+# ❌ 非 UUID 形式 → 新規 UUID が生成される
+headers = {"X-Request-Id": "test-req-001"}
+
+# ✅ UUID v4 形式 → そのまま転送される
+headers = {"X-Request-Id": "550e8400-e29b-41d4-a716-446655440000"}
+```
+
+テストでリクエスト ID を固定したい場合は `uuid.uuid4()` で生成するか、
+固定の UUID v4 文字列（第 3 グループが `4xxx`、第 4 グループが `[89ab]xxx`）を使う。
+この設計はログインジェクション対策のために意図的に行われている。


### PR DESCRIPTION
## Summary
- FT115: structlog + RequestLoggingMiddleware のコンテキスト伝播パターン検証レポートを追加
- `X-Request-Id` は UUID v4 のみ転送される設計（FP1）を how-to に記録
- `docs/how-to/structured-logging.md` を新規作成

## Test plan
- [ ] CI pass (pytest + mypy + ruff + pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)