### PR TITLE
docs: FT122 型安全イベントバス + dataclass kw_only パターンを追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-122.md
+++ b/docs/field-trials/2026-05-field-trial-122.md
@@ -1,0 +1,87 @@
+# Field Trial 122: 型安全なインプロセス イベントバス
+
+## テーマ
+
+`dataclass(frozen=True)` のイベント + 型変数を使ったジェネリックなハンドラー登録・発行パターンを検証する。
+ドメインイベントの publish/subscribe を型安全に実装し、FastAPI エンドポイントとの統合を確認する。
+
+## 実施内容
+
+`/home/xi/docker/nene2-python-FT/ft122-event-bus/` に以下を実装:
+
+- `DomainEvent` 基底クラス（`occurred_at: datetime` を `kw_only=True` で定義）
+- `OrderPlaced`, `OrderCancelled`, `PaymentReceived` — サブクラスドメインイベント
+- `EventBus` — `defaultdict` ベースのハンドラーレジストリ
+- `subscribe[E: DomainEvent]()` — ジェネリックメソッドで型安全なハンドラー登録
+- 9 テスト通過（修正後）
+
+## テスト結果
+
+1 件修正後、全 9 テスト通過。
+
+## Friction Points
+
+### FP1: dataclass 継承で「デフォルト引数の後に非デフォルト引数」エラー
+
+**状況**: `DomainEvent` の `occurred_at` フィールドに `default_factory` を設定し、
+サブクラス `OrderPlaced` で必須フィールド（`order_id` 等）を追加したところ、
+Python の dataclass 仕様でエラーになった。
+
+```
+TypeError: non-default argument 'order_id' follows default argument 'occurred_at'
+```
+
+デフォルト値を持つ親クラスフィールドの後に、サブクラスで必須フィールドを定義できない。
+
+```python
+# ❌ エラー: サブクラスの 'order_id' が親の 'occurred_at' の後に来る
+@dataclass(frozen=True)
+class DomainEvent:
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+@dataclass(frozen=True)
+class OrderPlaced(DomainEvent):
+    order_id: str  # ← 必須フィールドがデフォルト後 → TypeError
+
+# ✅ kw_only=True でキーワード専用にすることで解決（Python 3.10+）
+@dataclass(frozen=True)
+class DomainEvent:
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC), kw_only=True)
+
+@dataclass(frozen=True)
+class OrderPlaced(DomainEvent):
+    order_id: str  # OK — kw_only フィールドは順序制約を受けない
+```
+
+**影響**: 中。dataclass の継承でデフォルトフィールドを持つ基底クラスを設計する際に
+必ず発生する問題。`kw_only=True`（Python 3.10+）が最もクリーンな解決策。
+
+## 観察
+
+### O1: `EventBus` は `defaultdict(list)` で型ごとのハンドラーリストを管理できる
+
+```python
+class EventBus:
+    def __init__(self) -> None:
+        self._handlers: dict[type[DomainEvent], list[EventHandler[DomainEvent]]] = defaultdict(list)
+
+    def subscribe(self, event_type: type[E], handler: EventHandler[E]) -> None:
+        self._handlers[event_type].append(handler)
+
+    def publish(self, event: DomainEvent) -> None:
+        for handler in self._handlers.get(type(event), []):
+            handler(event)
+```
+
+`type(event)` を辞書キーにすることで、イベント型ごとのハンドラー一覧を O(1) で引ける。
+
+### O2: ハンドラー未登録のイベントは安全にスキップされる
+
+`defaultdict` でもキーが存在しない場合は `get()` で空リストが返るため、
+ハンドラーが未登録のイベントを publish しても例外が起きない。
+
+## まとめ
+
+FP1（dataclass 継承 + kw_only）を how-to/domain-events.md に追記予定。
+インプロセス イベントバスは `defaultdict` + ジェネリックハンドラーで
+最小コードで実装でき、テスト時には `EventBus.clear()` でリセットできる。

--- a/docs/how-to/domain-events.md
+++ b/docs/how-to/domain-events.md
@@ -117,3 +117,34 @@ assert executed[0].email == "alice@example.com"
 
 - `EventBus` はモジュールレベルのグローバル変数になりやすい。テスト間でハンドラーが蓄積する場合は `autouse` fixture でリセットする。
 - UseCase 内でイベントを発行する場合、UseCase の引数に `EventBus` を渡してコンストラクタインジェクションする（グローバル参照を避ける）。
+
+---
+
+## 5. dataclass 継承でデフォルト引数の後に必須引数を置く
+
+基底クラスに `default_factory` フィールドがある場合、サブクラスで必須フィールドを追加すると
+Python の dataclass 仕様でエラーになる。`kw_only=True`（Python 3.10+）で解決できる。
+
+```python
+# ❌ エラー: 'order_id' は 'occurred_at' の後に来る必須フィールド
+@dataclass(frozen=True)
+class DomainEvent:
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+@dataclass(frozen=True)
+class OrderPlaced(DomainEvent):
+    order_id: str  # TypeError: non-default argument follows default argument
+
+# ✅ kw_only=True で解決（Python 3.10+）
+@dataclass(frozen=True)
+class DomainEvent:
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC), kw_only=True)
+
+@dataclass(frozen=True)
+class OrderPlaced(DomainEvent):
+    order_id: str  # OK — kw_only フィールドは MRO の順序制約を受けない
+    total_amount: int
+```
+
+`kw_only=True` を指定すると `__init__` でキーワード引数専用になる。
+サブクラスの必須引数は通常の位置引数として定義でき、`occurred_at` はオプション扱いになる。


### PR DESCRIPTION
## Summary
- FT122: defaultdict + ジェネリックハンドラーによるインプロセスイベントバスの検証レポート
- FP1: dataclass 継承 + kw_only=True パターンを domain-events.md に追記
- 9テスト通過

## Test plan
- [ ] CI pass (pytest + mypy + ruff + pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)