### PR TITLE
fix(example): OpenAPI-aligned /health response #552

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -200,8 +200,12 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
     @app.get("/health", tags=["system"], summary="Health check")
     async def health() -> JSONResponse:
         status = db_health.check() if db_health else HealthStatus(status="ok")
+        api_status = "ok" if status.is_healthy else "degraded"
         code = 200 if status.is_healthy else 503
-        return JSONResponse({"status": status.status, "checks": status.checks}, status_code=code)
+        return JSONResponse(
+            {"status": api_status, "service": "NENE2", "checks": status.checks},
+            status_code=code,
+        )
 
     return app
 

--- a/tests/example/note/test_list_notes.py
+++ b/tests/example/note/test_list_notes.py
@@ -77,4 +77,6 @@ def test_delete_nonexistent_note_returns_404(client: TestClient) -> None:
 def test_health(client: TestClient) -> None:
     r = client.get("/health")
     assert r.status_code == 200
-    assert r.json()["status"] == "ok"
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "NENE2"


### PR DESCRIPTION
## Summary

Align example app `GET /health` with NENE2 OpenAPI `HealthResponse`:

- Add `service: "NENE2"`
- Use `status: degraded` (not internal `error`) when unhealthy, HTTP 503

Tracked from nene2-js live smoke / ADR 0003 parity.

Closes #552

## Test plan

- [ ] `pytest tests/example/note/test_list_notes.py::test_health`


Made with [Cursor](https://cursor.com)