### PR TITLE
feat(auth): CompositeAuthMiddleware — パスプレフィックスベース認証方式切り替え (#557)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.75"
+version = "1.8.76"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/auth/__init__.py
+++ b/src/nene2/auth/__init__.py
@@ -2,6 +2,13 @@
 
 from .api_key import ApiKeyAuthMiddleware
 from .bearer_token import BearerTokenMiddleware
+from .composite import (
+    AuthCheck,
+    CompositeAuthMiddleware,
+    CompositeAuthRule,
+    api_key_check,
+    bearer_check,
+)
 from .deps import make_require_auth
 from .exceptions import TokenVerificationException
 from .interfaces import TokenIssuerProtocol, TokenVerifierProtocol
@@ -9,10 +16,15 @@ from .local_verifier import LocalTokenVerifier
 
 __all__ = [
     "ApiKeyAuthMiddleware",
+    "AuthCheck",
     "BearerTokenMiddleware",
+    "CompositeAuthMiddleware",
+    "CompositeAuthRule",
     "LocalTokenVerifier",
     "TokenIssuerProtocol",
     "TokenVerificationException",
     "TokenVerifierProtocol",
+    "api_key_check",
+    "bearer_check",
     "make_require_auth",
 ]

--- a/src/nene2/auth/composite.py
+++ b/src/nene2/auth/composite.py
@@ -1,0 +1,129 @@
+"""CompositeAuthMiddleware — path-prefix-based auth strategy routing."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nene2.http.problem_details import problem_details_response
+
+from .exceptions import TokenVerificationException
+from .interfaces import TokenVerifierProtocol
+
+type AuthCheck = Callable[[Request], Response | None]
+
+_WWW_AUTH_BEARER = 'Bearer realm="api"'
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeAuthRule:
+    """Single routing rule: path prefix → authentication check.
+
+    Use :func:`bearer_check` or :func:`api_key_check` to build the ``check`` callable.
+    """
+
+    path_prefix: str
+    check: AuthCheck
+
+
+def bearer_check(verifier: TokenVerifierProtocol) -> AuthCheck:
+    """Build an AuthCheck that validates ``Authorization: Bearer <token>``."""
+
+    def _check(request: Request) -> Response | None:
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            resp = problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                "A valid Bearer token is required.",
+            )
+            resp.headers["WWW-Authenticate"] = _WWW_AUTH_BEARER
+            return resp
+        token = auth[len("Bearer ") :]
+        try:
+            verified = verifier.verify(token)
+        except TokenVerificationException:
+            verified = False
+        if not verified:
+            resp = problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                "The provided token is invalid or expired.",
+            )
+            resp.headers["WWW-Authenticate"] = _WWW_AUTH_BEARER
+            return resp
+        return None
+
+    return _check
+
+
+def api_key_check(
+    verifier: TokenVerifierProtocol,
+    header_name: str = "X-Api-Key",
+) -> AuthCheck:
+    """Build an AuthCheck that validates a configurable API key header."""
+
+    def _check(request: Request) -> Response | None:
+        api_key = request.headers.get(header_name, "")
+        try:
+            verified = bool(api_key) and verifier.verify(api_key)
+        except TokenVerificationException:
+            verified = False
+        if not verified:
+            return problem_details_response(
+                "unauthorized",
+                "Unauthorized",
+                401,
+                f"A valid {header_name} header is required.",
+            )
+        return None
+
+    return _check
+
+
+class CompositeAuthMiddleware(BaseHTTPMiddleware):
+    """Apply different auth strategies to different path prefixes.
+
+    Rules are evaluated in order; the first matching prefix wins.
+    If no rule matches, the request passes through unauthenticated.
+
+    Example::
+
+        from nene2.auth import (
+            CompositeAuthMiddleware,
+            CompositeAuthRule,
+            api_key_check,
+            bearer_check,
+        )
+
+        app.add_middleware(
+            CompositeAuthMiddleware,
+            rules=[
+                CompositeAuthRule("/webhook", api_key_check(webhook_verifier, "X-Webhook-Key")),
+                CompositeAuthRule("/api", bearer_check(token_verifier)),
+            ],
+        )
+    """
+
+    def __init__(
+        self,
+        app: object,
+        *,
+        rules: list[CompositeAuthRule],
+    ) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._rules = rules
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+        for rule in self._rules:
+            if path.startswith(rule.path_prefix):
+                rejection = rule.check(request)
+                if rejection is not None:
+                    return rejection
+                break
+        return await call_next(request)

--- a/tests/nene2/auth/test_composite_auth.py
+++ b/tests/nene2/auth/test_composite_auth.py
@@ -1,0 +1,134 @@
+"""CompositeAuthMiddleware / bearer_check / api_key_check のテスト。"""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.auth import (
+    CompositeAuthMiddleware,
+    CompositeAuthRule,
+    LocalTokenVerifier,
+    api_key_check,
+    bearer_check,
+)
+
+
+def _make_app(rules: list[CompositeAuthRule]) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CompositeAuthMiddleware, rules=rules)
+
+    @app.get("/api/notes")
+    async def notes() -> JSONResponse:
+        return JSONResponse({"resource": "api"})
+
+    @app.get("/webhook/event")
+    async def webhook() -> JSONResponse:
+        return JSONResponse({"resource": "webhook"})
+
+    @app.get("/public/status")
+    async def public() -> JSONResponse:
+        return JSONResponse({"resource": "public"})
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# bearer_check
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_check_valid_token_passes() -> None:
+    rules = [CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["tok"])))]
+    client = TestClient(_make_app(rules))
+    response = client.get("/api/notes", headers={"Authorization": "Bearer tok"})
+    assert response.status_code == 200
+
+
+def test_bearer_check_missing_header_returns_401() -> None:
+    rules = [CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["tok"])))]
+    client = TestClient(_make_app(rules))
+    response = client.get("/api/notes")
+    assert response.status_code == 401
+    assert "WWW-Authenticate" in response.headers
+
+
+def test_bearer_check_invalid_token_returns_401() -> None:
+    rules = [CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["tok"])))]
+    client = TestClient(_make_app(rules))
+    response = client.get("/api/notes", headers={"Authorization": "Bearer wrong"})
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# api_key_check
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_check_valid_key_passes() -> None:
+    check = api_key_check(LocalTokenVerifier(["secret"]), "X-Webhook-Key")
+    rules = [CompositeAuthRule("/webhook", check)]
+    client = TestClient(_make_app(rules))
+    response = client.get("/webhook/event", headers={"X-Webhook-Key": "secret"})
+    assert response.status_code == 200
+
+
+def test_api_key_check_missing_key_returns_401() -> None:
+    check = api_key_check(LocalTokenVerifier(["secret"]), "X-Webhook-Key")
+    rules = [CompositeAuthRule("/webhook", check)]
+    client = TestClient(_make_app(rules))
+    response = client.get("/webhook/event")
+    assert response.status_code == 401
+
+
+def test_api_key_check_default_header_name() -> None:
+    rules = [CompositeAuthRule("/webhook", api_key_check(LocalTokenVerifier(["key"])))]
+    client = TestClient(_make_app(rules))
+    response = client.get("/webhook/event", headers={"X-Api-Key": "key"})
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CompositeAuthMiddleware routing
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_path_passes_through() -> None:
+    rules = [CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["tok"])))]
+    client = TestClient(_make_app(rules))
+    response = client.get("/public/status")
+    assert response.status_code == 200
+
+
+def test_first_matching_rule_wins() -> None:
+    rules = [
+        CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["bearer-tok"]))),
+        CompositeAuthRule("/api", api_key_check(LocalTokenVerifier(["api-key"]))),
+    ]
+    client = TestClient(_make_app(rules))
+    response = client.get("/api/notes", headers={"Authorization": "Bearer bearer-tok"})
+    assert response.status_code == 200
+    response2 = client.get("/api/notes", headers={"X-Api-Key": "api-key"})
+    assert response2.status_code == 401
+
+
+def test_different_paths_use_different_auth() -> None:
+    wh_check = api_key_check(LocalTokenVerifier(["wh-key"]), "X-Webhook-Key")
+    rules = [
+        CompositeAuthRule("/api", bearer_check(LocalTokenVerifier(["bearer-tok"]))),
+        CompositeAuthRule("/webhook", wh_check),
+    ]
+    client = TestClient(_make_app(rules))
+    api_ok = client.get("/api/notes", headers={"Authorization": "Bearer bearer-tok"})
+    api_fail = client.get("/api/notes", headers={"X-Webhook-Key": "wh-key"})
+    wh_ok = client.get("/webhook/event", headers={"X-Webhook-Key": "wh-key"})
+    wh_fail = client.get("/webhook/event", headers={"Authorization": "Bearer bearer-tok"})
+    assert api_ok.status_code == 200
+    assert api_fail.status_code == 401
+    assert wh_ok.status_code == 200
+    assert wh_fail.status_code == 401
+
+
+def test_empty_rules_passes_all() -> None:
+    client = TestClient(_make_app([]))
+    assert client.get("/api/notes").status_code == 200
+    assert client.get("/webhook/event").status_code == 200


### PR DESCRIPTION
## Summary

- `CompositeAuthMiddleware` を追加 — PHP 版相当のパスプレフィックスベース認証方式ルーティング
- `CompositeAuthRule(path_prefix, check)` — 単一ルール定義（frozen dataclass）
- `bearer_check(verifier)` — `Authorization: Bearer <token>` を検証する AuthCheck ファクトリ
- `api_key_check(verifier, header_name?)` — API キーヘッダーを検証する AuthCheck ファクトリ
- ルールはリスト順に評価され、最初にマッチしたプレフィックスのチェックが適用される
- マッチするルールがない場合はそのまま通過

## Test plan

- [x] `uv run pytest` — 410 passed (93.64% coverage)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)