### PR TITLE
feat(middleware): RateLimitStorageProtocol / InMemoryRateLimitStorage — ThrottleMiddleware ストレージ抽象化 (#558)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.76"
+version = "1.8.77"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/middleware/__init__.py
+++ b/src/nene2/middleware/__init__.py
@@ -7,13 +7,15 @@ from .request_logging import RequestLoggingMiddleware
 from .request_size_limit import RequestSizeLimitMiddleware
 from .security_headers import SecurityHeadersMiddleware
 from .setup import setup_middlewares
-from .throttle import ThrottleMiddleware
+from .throttle import InMemoryRateLimitStorage, RateLimitStorageProtocol, ThrottleMiddleware
 
 __all__ = [
     "DomainExceptionHandlerProtocol",
     "SimpleDomainHandler",
     "ErrorHandlerMiddleware",
     "request_validation_error_handler",
+    "InMemoryRateLimitStorage",
+    "RateLimitStorageProtocol",
     "RequestIdMiddleware",
     "get_request_id",
     "RequestLoggingMiddleware",

--- a/src/nene2/middleware/throttle.py
+++ b/src/nene2/middleware/throttle.py
@@ -1,9 +1,13 @@
 """Fixed-window rate limiting middleware.
 
-Tracks request counts per client IP in an in-memory dict.
-Exceeding the limit returns 429 with a Retry-After header.
+Tracks request counts per client IP via a pluggable storage backend.
+The default backend (``InMemoryRateLimitStorage``) works in a single process.
+For multi-process or multi-container deployments, supply a Redis-backed
+implementation of ``RateLimitStorageProtocol``.
+
 All responses include ``X-RateLimit-Limit``, ``X-RateLimit-Remaining``, and
 ``X-RateLimit-Reset`` headers so clients can adapt their request rate.
+Exceeding the limit returns 429 with a ``Retry-After`` header.
 
 .. warning::
     ``X-Forwarded-For`` is trusted as-is when present.  In environments
@@ -16,6 +20,7 @@ All responses include ``X-RateLimit-Limit``, ``X-RateLimit-Remaining``, and
 import threading
 import time
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -25,6 +30,60 @@ from nene2.http.problem_details import problem_details_response
 
 _DEFAULT_LIMIT = 60
 _DEFAULT_WINDOW = 60  # seconds
+
+
+@runtime_checkable
+class RateLimitStorageProtocol(Protocol):
+    """Pluggable backend for ``ThrottleMiddleware``.
+
+    Implementations must atomically increment a counter and return the
+    post-increment count together with the window start timestamp.
+
+    The ``acquire`` method is called once per request and must be
+    thread-safe (or use a distributed lock for shared backends).
+    """
+
+    def acquire(self, key: str, now: float, window: float) -> tuple[int, float]:
+        """Increment the counter for *key* and return ``(count, window_start)``.
+
+        When the current window has expired (``now - window_start >= window``),
+        the counter resets to 1 and ``window_start`` is set to ``now``.
+        """
+        ...  # pragma: no cover
+
+
+class InMemoryRateLimitStorage:
+    """Thread-safe in-memory fixed-window counter.
+
+    .. warning:: **Single-process only.**
+        Each process maintains its own counters.  When running multiple
+        workers or containers the effective limit is ``limit × worker_count``.
+        Use a shared store (Redis) for multi-process deployments.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[str, tuple[int, float]] = {}
+        self._lock = threading.Lock()
+        self._last_cleanup: float = 0.0
+
+    def acquire(self, key: str, now: float, window: float) -> tuple[int, float]:
+        with self._lock:
+            self._maybe_evict(now, window)
+            count, window_start = self._counts.get(key, (0, now))
+            if now - window_start >= window:
+                count, window_start = 0, now
+            count += 1
+            self._counts[key] = (count, window_start)
+        return (count, window_start)
+
+    def _maybe_evict(self, now: float, window: float) -> None:
+        if now - self._last_cleanup < window:
+            return
+        self._last_cleanup = now
+        cutoff = now - window
+        stale = [k for k, (_, ws) in self._counts.items() if ws < cutoff]
+        for k in stale:
+            del self._counts[k]
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +101,15 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
     ``X-RateLimit-Reset`` headers to every response so clients can monitor
     their quota.  On 429, also adds ``Retry-After``.
 
+    Pass a custom ``storage`` to swap in a Redis or other shared backend::
+
+        app.add_middleware(
+            ThrottleMiddleware,
+            limit=100,
+            window=60,
+            storage=MyRedisStorage(redis_client),
+        )
+
     Use ``path_limits`` to apply stricter limits on specific paths::
 
         app.add_middleware(
@@ -55,14 +123,6 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
     Path-limited endpoints are tracked independently from the global counter
     (the key includes the path, so ``/api/expensive`` quota is separate from
     the default quota for other paths).
-
-    .. warning:: **Single-process only.**
-        Counters are stored in an in-memory dict.  When running multiple
-        uvicorn workers (e.g. ``gunicorn -w 4``) or multiple containers,
-        each process maintains its own counter, so the effective rate limit
-        is ``limit × worker_count``.  For multi-process deployments, enforce
-        rate limits at the reverse proxy (nginx, Caddy) or use a shared
-        store (Redis).
 
     .. note:: **Fixed-window burst at boundaries.**
         Fixed-window counting can pass up to ``2 × limit`` requests in a
@@ -79,15 +139,14 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
         window: int = _DEFAULT_WINDOW,
         path_limits: dict[str, int] | None = None,
         exclude_paths: list[str] | None = None,
+        storage: RateLimitStorageProtocol | None = None,
     ) -> None:
         super().__init__(app)  # type: ignore[arg-type]
         self._limit = limit
         self._window = window
         self._path_limits: dict[str, int] = path_limits or {}
         self._exclude_paths = set(exclude_paths or [])
-        self._counts: dict[str, tuple[int, float]] = {}
-        self._lock = threading.Lock()
-        self._last_cleanup: float = 0.0
+        self._storage: RateLimitStorageProtocol = storage or InMemoryRateLimitStorage()
 
     def _client_key(self, request: Request) -> str:
         forwarded = request.headers.get("X-Forwarded-For")
@@ -95,29 +154,14 @@ class ThrottleMiddleware(BaseHTTPMiddleware):
             return forwarded.split(",")[0].strip()
         return request.client.host if request.client else "unknown"
 
-    def _evict_stale(self, now: float) -> None:
-        if now - self._last_cleanup < self._window:
-            return
-        self._last_cleanup = now
-        cutoff = now - self._window
-        stale = [k for k, (_, ws) in self._counts.items() if ws < cutoff]
-        for k in stale:
-            del self._counts[k]
-
     def _check_rate(self, key: str, limit: int) -> _RateInfo:
         now = time.monotonic()
         wall_now = int(time.time())
-        with self._lock:
-            self._evict_stale(now)
-            count, window_start = self._counts.get(key, (0, now))
-            if now - window_start >= self._window:
-                count, window_start = 0, now
-            count += 1
-            self._counts[key] = (count, window_start)
-            elapsed = int(now - window_start)
-            retry_after = max(0, self._window - elapsed)
-            reset_at = wall_now + retry_after
-            remaining = max(0, limit - count)
+        count, window_start = self._storage.acquire(key, now, self._window)
+        elapsed = int(now - window_start)
+        retry_after = max(0, self._window - elapsed)
+        reset_at = wall_now + retry_after
+        remaining = max(0, limit - count)
         return _RateInfo(
             allowed=count <= limit,
             remaining=remaining,

--- a/tests/nene2/middleware/test_throttle.py
+++ b/tests/nene2/middleware/test_throttle.py
@@ -1,4 +1,4 @@
-"""Tests for ThrottleMiddleware."""
+"""Tests for ThrottleMiddleware / InMemoryRateLimitStorage / RateLimitStorageProtocol."""
 
 import time
 
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from nene2.middleware import ThrottleMiddleware
+from nene2.middleware import InMemoryRateLimitStorage, RateLimitStorageProtocol, ThrottleMiddleware
 
 
 def _make_app(limit: int = 3, window: int = 60) -> FastAPI:
@@ -173,18 +173,37 @@ def test_path_limit_reflected_in_x_ratelimit_limit_header() -> None:
 
 
 def test_stale_entries_are_evicted_after_window_expires() -> None:
-    app = FastAPI()
-    middleware = ThrottleMiddleware(app, limit=100, window=1)
-
+    storage = InMemoryRateLimitStorage()
+    now = time.monotonic()
     for i in range(10):
-        middleware._check_rate(f"192.168.1.{i}", 100)
+        storage.acquire(f"192.168.1.{i}", now, 1.0)
 
-    assert len(middleware._counts) == 10
+    assert len(storage._counts) == 10
 
     time.sleep(1.1)
 
     # 新しいリクエストでクリーンアップがトリガーされる
-    middleware._check_rate("10.0.0.99", 100)
+    storage.acquire("10.0.0.99", time.monotonic(), 1.0)
 
     # 古い 10 エントリは削除され、新しい 1 エントリのみ残る
-    assert len(middleware._counts) == 1
+    assert len(storage._counts) == 1
+
+
+def test_custom_storage_is_used_by_throttle_middleware() -> None:
+    storage = InMemoryRateLimitStorage()
+    app = FastAPI()
+    app.add_middleware(ThrottleMiddleware, limit=2, window=60, storage=storage)
+
+    @app.get("/ping")
+    async def ping() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 429
+
+
+def test_rate_limit_storage_protocol_is_satisfied() -> None:
+    storage = InMemoryRateLimitStorage()
+    assert isinstance(storage, RateLimitStorageProtocol)


### PR DESCRIPTION
## Summary

- `RateLimitStorageProtocol` を追加 — ThrottleMiddleware のストレージ抽象化プロトコル（`@runtime_checkable`）
  - `acquire(key, now, window) -> tuple[int, float]` — アトミックなカウンタ増分
- `InMemoryRateLimitStorage` を追加 — シングルプロセス向けのスレッドセーフ in-memory 実装
  - stale エントリの自動 evict（window 経過後）
- `ThrottleMiddleware` に `storage: RateLimitStorageProtocol | None = None` を追加
  - デフォルトは `InMemoryRateLimitStorage()` （既存動作と完全互換）
  - Redis等の共有ストアを渡すことでマルチプロセス対応が可能に
- `nene2.middleware` から `RateLimitStorageProtocol` / `InMemoryRateLimitStorage` を公開
- テストを更新: `_counts` への直接アクセスを `InMemoryRateLimitStorage` 単体テストに置き換え

## Test plan

- [x] `uv run pytest` — 412 passed (93.67% coverage)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)