### PR TITLE
feat(auth): LocalTokenIssuer / LocalTokenIssuerVerifier — 開発用 HMAC 署名トークン発行 (#559)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.77"
+version = "1.8.78"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/auth/__init__.py
+++ b/src/nene2/auth/__init__.py
@@ -12,6 +12,7 @@ from .composite import (
 from .deps import make_require_auth
 from .exceptions import TokenVerificationException
 from .interfaces import TokenIssuerProtocol, TokenVerifierProtocol
+from .local_issuer import LocalTokenIssuer, LocalTokenIssuerVerifier
 from .local_verifier import LocalTokenVerifier
 
 __all__ = [
@@ -20,6 +21,8 @@ __all__ = [
     "BearerTokenMiddleware",
     "CompositeAuthMiddleware",
     "CompositeAuthRule",
+    "LocalTokenIssuer",
+    "LocalTokenIssuerVerifier",
     "LocalTokenVerifier",
     "TokenIssuerProtocol",
     "TokenVerificationException",

--- a/src/nene2/auth/local_issuer.py
+++ b/src/nene2/auth/local_issuer.py
@@ -1,0 +1,70 @@
+"""LocalTokenIssuer / LocalTokenIssuerVerifier — HMAC-signed dev tokens.
+
+For development and testing only.  In production use a proper JWT library
+(e.g. PyJWT) backed by your key management system.
+"""
+
+import base64
+import hmac
+import json
+
+
+class LocalTokenIssuer:
+    """Issue self-contained HMAC-SHA256-signed tokens for development/testing.
+
+    Generates tokens as ``{b64url_claims}.{hmac_hex}`` so claims are
+    readable without a round-trip to a token store.
+
+    Pair with :class:`LocalTokenIssuerVerifier` using the same *signing_key*
+    to create a complete dev auth setup::
+
+        key = "dev-secret"
+        issuer = LocalTokenIssuer(key)
+        verifier = LocalTokenIssuerVerifier(key)
+
+        token = issuer.issue({"sub": "user-1", "role": "admin"})
+        verifier.verify(token)  # → True
+        verifier.decode(token)  # → {"sub": "user-1", "role": "admin"}
+    """
+
+    def __init__(self, signing_key: str) -> None:
+        self._key = signing_key.encode("utf-8")
+
+    def issue(self, claims: dict[str, object]) -> str:
+        payload = json.dumps(claims, sort_keys=True, ensure_ascii=False)
+        b64 = base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+        sig = hmac.new(self._key, b64.encode(), digestmod="sha256").hexdigest()
+        return f"{b64}.{sig}"
+
+
+class LocalTokenIssuerVerifier:
+    """Verify and decode tokens issued by :class:`LocalTokenIssuer`.
+
+    Implements :class:`~nene2.auth.TokenVerifierProtocol`.
+    """
+
+    def __init__(self, signing_key: str) -> None:
+        self._key = signing_key.encode("utf-8")
+
+    def verify(self, token: str) -> bool:
+        """Return True if the token has a valid HMAC signature."""
+        try:
+            b64, sig = token.rsplit(".", 1)
+        except ValueError:
+            return False
+        expected = hmac.new(self._key, b64.encode(), digestmod="sha256").hexdigest()
+        return hmac.compare_digest(sig, expected)
+
+    def decode(self, token: str) -> dict[str, object] | None:
+        """Return the decoded claims if the token is valid, else None."""
+        try:
+            b64, sig = token.rsplit(".", 1)
+        except ValueError:
+            return None
+        expected = hmac.new(self._key, b64.encode(), digestmod="sha256").hexdigest()
+        if not hmac.compare_digest(sig, expected):
+            return None
+        padding = (4 - len(b64) % 4) % 4
+        decoded = base64.urlsafe_b64decode(b64 + "=" * padding)
+        result: dict[str, object] = json.loads(decoded)
+        return result

--- a/tests/nene2/auth/test_local_issuer.py
+++ b/tests/nene2/auth/test_local_issuer.py
@@ -1,0 +1,116 @@
+"""LocalTokenIssuer / LocalTokenIssuerVerifier のテスト。"""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nene2.auth import (
+    BearerTokenMiddleware,
+    LocalTokenIssuer,
+    LocalTokenIssuerVerifier,
+    TokenIssuerProtocol,
+    TokenVerifierProtocol,
+)
+
+_KEY = "test-signing-key"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_local_token_issuer_satisfies_protocol() -> None:
+    assert isinstance(LocalTokenIssuer(_KEY), TokenIssuerProtocol)
+
+
+def test_local_token_issuer_verifier_satisfies_verifier_protocol() -> None:
+    assert isinstance(LocalTokenIssuerVerifier(_KEY), TokenVerifierProtocol)
+
+
+# ---------------------------------------------------------------------------
+# issue / verify round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_issued_token_verifies_successfully() -> None:
+    issuer = LocalTokenIssuer(_KEY)
+    verifier = LocalTokenIssuerVerifier(_KEY)
+    token = issuer.issue({"sub": "user-1"})
+    assert verifier.verify(token) is True
+
+
+def test_token_from_different_key_fails_verification() -> None:
+    issuer = LocalTokenIssuer("key-a")
+    verifier = LocalTokenIssuerVerifier("key-b")
+    assert verifier.verify(issuer.issue({"sub": "x"})) is False
+
+
+def test_tampered_token_fails_verification() -> None:
+    issuer = LocalTokenIssuer(_KEY)
+    verifier = LocalTokenIssuerVerifier(_KEY)
+    token = issuer.issue({"sub": "user-1"})
+    tampered = token[:-4] + "zzzz"
+    assert verifier.verify(tampered) is False
+
+
+def test_malformed_token_fails_verification() -> None:
+    verifier = LocalTokenIssuerVerifier(_KEY)
+    assert verifier.verify("no-dot-here") is False
+    assert verifier.verify("") is False
+
+
+# ---------------------------------------------------------------------------
+# decode
+# ---------------------------------------------------------------------------
+
+
+def test_decode_returns_original_claims() -> None:
+    issuer = LocalTokenIssuer(_KEY)
+    verifier = LocalTokenIssuerVerifier(_KEY)
+    claims: dict[str, object] = {"sub": "user-1", "role": "admin", "n": 42}
+    token = issuer.issue(claims)
+    decoded = verifier.decode(token)
+    assert decoded == claims
+
+
+def test_decode_returns_none_for_invalid_token() -> None:
+    verifier = LocalTokenIssuerVerifier(_KEY)
+    assert verifier.decode("invalid") is None
+    assert verifier.decode("part1.badsig") is None
+
+
+def test_different_claims_produce_different_tokens() -> None:
+    issuer = LocalTokenIssuer(_KEY)
+    t1 = issuer.issue({"sub": "a"})
+    t2 = issuer.issue({"sub": "b"})
+    assert t1 != t2
+
+
+def test_same_claims_produce_same_token() -> None:
+    issuer = LocalTokenIssuer(_KEY)
+    claims: dict[str, object] = {"sub": "user-1", "role": "viewer"}
+    assert issuer.issue(claims) == issuer.issue(claims)
+
+
+# ---------------------------------------------------------------------------
+# Integration with BearerTokenMiddleware
+# ---------------------------------------------------------------------------
+
+
+def test_integration_with_bearer_middleware() -> None:
+    key = "integration-key"
+    issuer = LocalTokenIssuer(key)
+    verifier = LocalTokenIssuerVerifier(key)
+
+    app = FastAPI()
+    app.add_middleware(BearerTokenMiddleware, verifier=verifier)
+
+    @app.get("/secure")
+    async def secure() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    client = TestClient(app)
+    token = issuer.issue({"sub": "test-user"})
+    assert client.get("/secure", headers={"Authorization": f"Bearer {token}"}).status_code == 200
+    assert client.get("/secure", headers={"Authorization": "Bearer bad"}).status_code == 401


### PR DESCRIPTION
## Summary

- `LocalTokenIssuer` を追加 — HMAC-SHA256 署名の開発用トークン発行（`TokenIssuerProtocol` 実装）
  - `issue(claims)` → `{b64url_claims}.{hmac_hex}` 形式のトークンを生成
  - クレームは URL-safe Base64 エンコードされているため、デバッグ時に可読
- `LocalTokenIssuerVerifier` を追加 — 対応する検証クラス（`TokenVerifierProtocol` 実装）
  - `verify(token)` → HMAC 署名の timing-safe 検証
  - `decode(token)` → 署名検証後にクレームを返す（無効な場合は None）
- `nene2.auth` から両クラスを公開
- `BearerTokenMiddleware` との統合テスト含む 11 テストケース

## Test plan

- [x] `uv run pytest` — 423 passed (93.78% coverage)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)