### PR TITLE
feat(http): query ヘルパー関数群・RequestScopedContext を追加 (#560 #561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.78"
+version = "1.8.79"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nene2/http/__init__.py
+++ b/src/nene2/http/__init__.py
@@ -1,5 +1,6 @@
 """HTTP helpers — JSON responses, pagination, problem details, health."""
 
+from .context import RequestScopedContext
 from .etag import check_not_modified, check_precondition, generate_etag
 from .health import (
     AsyncCompositeHealthCheck,
@@ -15,8 +16,10 @@ from .problem_details import (
     problem_details_response,
     reset_problem_details,
 )
+from .query import query_array, query_bool, query_comma_separated, query_int, query_string
 
 __all__ = [
+    "RequestScopedContext",
     "check_not_modified",
     "check_precondition",
     "generate_etag",
@@ -32,5 +35,10 @@ __all__ = [
     "PROBLEM_DETAILS_BASE_URL",
     "configure_problem_details",
     "problem_details_response",
+    "query_array",
+    "query_bool",
+    "query_comma_separated",
+    "query_int",
+    "query_string",
     "reset_problem_details",
 ]

--- a/src/nene2/http/context.py
+++ b/src/nene2/http/context.py
@@ -1,0 +1,44 @@
+"""RequestScopedContext — ContextVar ベースのリクエストスコープ値ホルダー。
+
+ASGI ではリクエストごとに ContextVar が独立するため、複数リクエストで値が混在しない。
+ミドルウェアで設定した値をハンドラーや下位レイヤーで型安全に取り出せる。
+
+Example::
+
+    tenant_id: RequestScopedContext[int] = RequestScopedContext()
+
+    # Middleware
+    tenant_id.set(extract_tenant_id(request))
+
+    # Handler
+    tid = tenant_id.get()
+"""
+
+from contextvars import ContextVar
+
+_SENTINEL = object()
+
+
+class RequestScopedContext[T]:
+    """ContextVar ラッパー — ASGI リクエストスコープの型安全な値ホルダー。"""
+
+    def __init__(self) -> None:
+        self._var: ContextVar[object] = ContextVar(f"RequestScopedContext_{id(self)}")
+
+    def set(self, value: T) -> None:
+        """値を現在のコンテキストにセットする。"""
+        self._var.set(value)
+
+    def get(self) -> T:
+        """値を取得する。未セットの場合は ``LookupError`` を送出する。"""
+        value = self._var.get(_SENTINEL)
+        if value is _SENTINEL:
+            raise LookupError("RequestScopedContext value has not been set for this request.")
+        return value  # type: ignore[return-value]
+
+    def get_or_none(self) -> T | None:
+        """値を取得する。未セットの場合は ``None`` を返す。"""
+        value = self._var.get(_SENTINEL)
+        if value is _SENTINEL:
+            return None
+        return value  # type: ignore[return-value]

--- a/src/nene2/http/query.py
+++ b/src/nene2/http/query.py
@@ -1,0 +1,67 @@
+"""型付きクエリパラメータ抽出ヘルパー。
+
+FastAPI の Query() 型注釈が使えないコンテキスト（ミドルウェア・共通処理）で
+Request オブジェクトからクエリパラメータを型安全に取り出す。
+"""
+
+from starlette.requests import Request
+
+
+def query_string(request: Request, key: str, default: str | None = None) -> str | None:
+    """クエリパラメータを文字列として取得する。"""
+    return request.query_params.get(key, default)
+
+
+def query_int(request: Request, key: str, default: int | None = None) -> int | None:
+    """クエリパラメータを整数として取得する。変換できない場合は *default* を返す。"""
+    raw = request.query_params.get(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def query_bool(request: Request, key: str, default: bool | None = None) -> bool | None:
+    """クエリパラメータを bool として取得する。
+
+    ``"true"`` / ``"1"`` / ``"yes"`` → ``True``、
+    ``"false"`` / ``"0"`` / ``"no"`` → ``False``（大文字小文字を問わない）。
+    それ以外の値は *default* を返す。
+    """
+    raw = request.query_params.get(key)
+    if raw is None:
+        return default
+    lower = raw.lower()
+    if lower in ("true", "1", "yes"):
+        return True
+    if lower in ("false", "0", "no"):
+        return False
+    return default
+
+
+def query_comma_separated(request: Request, key: str) -> list[str] | None:
+    """カンマ区切りのクエリパラメータをリストとして取得する。
+
+    空要素は除外する。パラメータが存在しない場合は ``None`` を返す。
+
+    Example: ``?tags=a,b,c`` → ``["a", "b", "c"]``
+    """
+    raw = request.query_params.get(key)
+    if raw is None:
+        return None
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def query_array(request: Request, key: str) -> list[str] | None:
+    """同一キーの複数値をリストとして取得する。
+
+    パラメータが存在しない場合は ``None`` を返す。
+
+    Example: ``?ids=1&ids=2&ids=3`` → ``["1", "2", "3"]``
+    """
+    values = request.query_params.getlist(key)
+    if not values:
+        return None
+    return values

--- a/tests/nene2/http/test_context.py
+++ b/tests/nene2/http/test_context.py
@@ -1,0 +1,68 @@
+"""RequestScopedContext のテスト。"""
+
+import asyncio
+
+import pytest
+
+from nene2.http import RequestScopedContext
+
+
+def test_set_and_get_returns_value() -> None:
+    ctx: RequestScopedContext[str] = RequestScopedContext()
+    ctx.set("hello")
+    assert ctx.get() == "hello"
+
+
+def test_get_or_none_returns_none_when_unset() -> None:
+    ctx: RequestScopedContext[int] = RequestScopedContext()
+    assert ctx.get_or_none() is None
+
+
+def test_get_raises_lookup_error_when_unset() -> None:
+    ctx: RequestScopedContext[int] = RequestScopedContext()
+    with pytest.raises(LookupError):
+        ctx.get()
+
+
+def test_set_overwrites_previous_value() -> None:
+    ctx: RequestScopedContext[int] = RequestScopedContext()
+    ctx.set(1)
+    ctx.set(2)
+    assert ctx.get() == 2
+
+
+def test_different_instances_are_independent() -> None:
+    ctx_a: RequestScopedContext[str] = RequestScopedContext()
+    ctx_b: RequestScopedContext[str] = RequestScopedContext()
+    ctx_a.set("a")
+    ctx_b.set("b")
+    assert ctx_a.get() == "a"
+    assert ctx_b.get() == "b"
+
+
+def test_async_contexts_are_isolated() -> None:
+    ctx: RequestScopedContext[str] = RequestScopedContext()
+    results: list[str] = []
+
+    async def task_a() -> None:
+        ctx.set("request-a")
+        await asyncio.sleep(0)
+        results.append(ctx.get())
+
+    async def task_b() -> None:
+        ctx.set("request-b")
+        await asyncio.sleep(0)
+        results.append(ctx.get())
+
+    async def run() -> None:
+        await asyncio.gather(task_a(), task_b())
+
+    asyncio.run(run())
+    assert sorted(results) == ["request-a", "request-b"]
+
+
+def test_none_value_stored_correctly() -> None:
+    ctx: RequestScopedContext[str | None] = RequestScopedContext()
+    ctx.set(None)
+    assert ctx.get() is None
+    assert ctx.get_or_none() is None

--- a/tests/nene2/http/test_query.py
+++ b/tests/nene2/http/test_query.py
@@ -1,0 +1,117 @@
+"""query_string / query_int / query_bool / query_comma_separated / query_array のテスト。"""
+
+import pytest
+from starlette.requests import Request
+
+from nene2.http import query_array, query_bool, query_comma_separated, query_int, query_string
+
+
+def _make_request(query: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": query.encode(),
+        "headers": [],
+    }
+    return Request(scope)
+
+
+# ---------------------------------------------------------------------------
+# query_string
+# ---------------------------------------------------------------------------
+
+
+def test_query_string_returns_value() -> None:
+    assert query_string(_make_request("name=alice"), "name") == "alice"
+
+
+def test_query_string_returns_default_when_missing() -> None:
+    assert query_string(_make_request(""), "name") is None
+    assert query_string(_make_request(""), "name", "anon") == "anon"
+
+
+# ---------------------------------------------------------------------------
+# query_int
+# ---------------------------------------------------------------------------
+
+
+def test_query_int_parses_integer() -> None:
+    assert query_int(_make_request("page=3"), "page") == 3
+
+
+def test_query_int_returns_default_on_missing() -> None:
+    assert query_int(_make_request(""), "page") is None
+    assert query_int(_make_request(""), "page", 1) == 1
+
+
+def test_query_int_returns_default_on_invalid() -> None:
+    assert query_int(_make_request("page=abc"), "page") is None
+    assert query_int(_make_request("page=abc"), "page", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# query_bool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["true", "True", "TRUE", "1", "yes", "Yes"])
+def test_query_bool_true_values(raw: str) -> None:
+    assert query_bool(_make_request(f"flag={raw}"), "flag") is True
+
+
+@pytest.mark.parametrize("raw", ["false", "False", "FALSE", "0", "no", "No"])
+def test_query_bool_false_values(raw: str) -> None:
+    assert query_bool(_make_request(f"flag={raw}"), "flag") is False
+
+
+def test_query_bool_returns_default_on_missing() -> None:
+    assert query_bool(_make_request(""), "flag") is None
+    assert query_bool(_make_request(""), "flag", True) is True
+
+
+def test_query_bool_returns_default_on_invalid() -> None:
+    assert query_bool(_make_request("flag=maybe"), "flag") is None
+
+
+# ---------------------------------------------------------------------------
+# query_comma_separated
+# ---------------------------------------------------------------------------
+
+
+def test_query_comma_separated_returns_list() -> None:
+    result = query_comma_separated(_make_request("tags=a,b,c"), "tags")
+    assert result == ["a", "b", "c"]
+
+
+def test_query_comma_separated_strips_whitespace() -> None:
+    result = query_comma_separated(_make_request("tags=a%2C+b%2C+c"), "tags")
+    assert result == ["a", "b", "c"]
+
+
+def test_query_comma_separated_returns_none_when_missing() -> None:
+    assert query_comma_separated(_make_request(""), "tags") is None
+
+
+def test_query_comma_separated_skips_empty_parts() -> None:
+    result = query_comma_separated(_make_request("tags=a,,b,"), "tags")
+    assert result == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# query_array
+# ---------------------------------------------------------------------------
+
+
+def test_query_array_returns_multiple_values() -> None:
+    result = query_array(_make_request("ids=1&ids=2&ids=3"), "ids")
+    assert result == ["1", "2", "3"]
+
+
+def test_query_array_returns_none_when_missing() -> None:
+    assert query_array(_make_request(""), "ids") is None
+
+
+def test_query_array_returns_single_value_as_list() -> None:
+    result = query_array(_make_request("ids=42"), "ids")
+    assert result == ["42"]


### PR DESCRIPTION
## Summary

**#560 QueryStringParser ヘルパー関数群**:
- `query_string(request, key, default?)` — 文字列クエリパラメータ取得
- `query_int(request, key, default?)` — 整数変換・失敗時は default
- `query_bool(request, key, default?)` — `true/1/yes` / `false/0/no` の bool 変換
- `query_comma_separated(request, key)` — カンマ区切り → リスト
- `query_array(request, key)` — 同一キーの複数値 → リスト
- FastAPI の `Query()` が使えないミドルウェア・共通処理コンテキスト向け

**#561 RequestScopedContext[T]**:
- `RequestScopedContext[T]` — ContextVar ラッパーのジェネリッククラス（Python 3.12+ 構文）
- `set(value)` / `get()` / `get_or_none()` の 3 メソッド
- ASGI では ContextVar がリクエストごとに独立するため、並行リクエストで値が混在しない
- `get()` は未セット時に `LookupError` を送出

## Test plan

- [x] `uv run pytest` — 456 passed (93.98% coverage)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — no issues

Closes #560
Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)