### PR TITLE
fix(example): notes 422 returns title and body errors

### DIFF
--- a/src/example/note/handler.py
+++ b/src/example/note/handler.py
@@ -63,6 +63,8 @@ def make_note_router(
         errors: list[ValidationError] = []
         if not body.title.strip():
             errors.append(ValidationError("title", "Title must not be empty.", "required"))
+        if not body.body.strip():
+            errors.append(ValidationError("body", "Body must not be empty.", "required"))
         if errors:
             raise ValidationException(errors)
 
@@ -76,6 +78,8 @@ def make_note_router(
         errors: list[ValidationError] = []
         if not body.title.strip():
             errors.append(ValidationError("title", "Title must not be empty.", "required"))
+        if not body.body.strip():
+            errors.append(ValidationError("body", "Body must not be empty.", "required"))
         if errors:
             raise ValidationException(errors)
 

--- a/tests/example/note/test_list_notes.py
+++ b/tests/example/note/test_list_notes.py
@@ -30,6 +30,13 @@ def test_create_note_empty_title_returns_422(client: TestClient) -> None:
     assert r.json()["errors"][0]["field"] == "title"
 
 
+def test_create_note_empty_title_and_body_returns_all_fields(client: TestClient) -> None:
+    r = client.post("/examples/notes", json={"title": "", "body": ""})
+    assert r.status_code == 422
+    fields = {e["field"] for e in r.json()["errors"]}
+    assert fields == {"title", "body"}
+
+
 def test_get_nonexistent_note_returns_404(client: TestClient) -> None:
     r = client.get("/examples/notes/9999")
     assert r.status_code == 404


### PR DESCRIPTION
Closes #588

PHP NENE2 parity: empty title+body returns both field errors.

## Test plan
- [x] pytest tests/example/note/test_list_notes.py

Made with [Cursor](https://cursor.com)