### PR TITLE
docs: 2026-05-23 日報を追加（FT213〜FT218）

### DIFF
--- a/docs/review/2026-05-23.md
+++ b/docs/review/2026-05-23.md
@@ -1,0 +1,83 @@
+# 日報 — 2026-05-23
+
+**作業者**: hideyukiMORI  
+**バージョン**: v1.8.95（セッション終了時点）
+
+---
+
+## 本日の作業サマリー
+
+### 完了した FT（6 件）
+
+| FT | テーマ | 診断・ペンテスト |
+|---|---|---|
+| FT213 | abc — ABC / abstractmethod / register / __subclasshook__ | セキュリティ診断 |
+| FT214 | io — StringIO / BytesIO / TextIOWrapper / BufferedReader | — |
+| FT215 | struct — pack / unpack / calcsize / Struct / byte order | — |
+| FT216 | codecs — encode / decode / lookup / IncrementalEncoder | セキュリティ診断 + クラッカーペンテスト |
+| FT217 | csv — reader / writer / DictReader / DictWriter / Sniffer | — |
+| FT218 | configparser — read / write / sections / interpolation | — |
+
+テーマの流れ: **オブジェクト指向基盤（FT213）→ I/O（FT214〜215）→ エンコーディング（FT216）→ データフォーマット（FT217〜218）** の縦断。
+
+### 主な摩擦点・発見
+
+| FT | 摩擦点 | 対処 |
+|---|---|---|
+| FT213 | `__subclasshook__` の `bool \| NotImplementedType` が mypy strict でエラー | `bool` のみを返す形に簡略化 |
+| FT213 | Infinity/NaN が float フィールドに入ると 500 DoS（Issue #594） | `_sanitize_value()` + カスタム `RequestValidationError` ハンドラーで修正（ローカル対処） |
+| FT214 | `StringIO.tell()` を `seek(0)` 後に呼ぶと文字数でなく EOF 位置を返す | `seek(0)` 前に `tell()` を呼ぶよう実装・テスト修正 |
+| FT214 | `TextIOWrapper` で `BytesIO` をラップする際 `write_through=True` がないと `getvalue()` が空になる | `write_through=True` を明示 |
+| FT215 | struct フォーマット文字列インジェクションの防御 | `_SAFE_FORMAT_CHARS` ホワイトリストを実装 |
+| FT216 | `codecs.encode()` の戻り値型が `bytes \| str` で mypy strict がエラー | `str.encode()` / `bytes.decode()` に置換（機能的に等価） |
+| FT217 | `Sniffer.dialect.quotechar` が `str \| None` で mypy エラー | `or '"'` フォールバックを追加 |
+| FT218 | `DuplicateSectionError` が `configparser.Error` のサブクラス | `except (ValueError, configparser.Error)` で 422 に変換 |
+
+### 達成度評価
+
+| 項目 | 評価 |
+|---|---|
+| FT 件数（6 本/日） | **A** |
+| セキュリティ診断の質（FT213: HIGH 修正、FT216: 合格） | **S** |
+| mypy --strict / ruff 全通過 | **S** |
+| 積み残しゼロで終了 | **A** |
+| テスト数（約 120 件追加） | **A** |
+
+**総合: A**
+
+---
+
+## コードベース評価レポート（AI 所見）
+
+### 今日のループで見えてきたこと
+
+**Infinity/NaN DoS の再現性**  
+FT212（dataclasses）で発見した Infinity/NaN 500 エラーが FT213（abc）でも再現した。float フィールドを持つ FT では毎回同じ `_sanitize_value()` パターンを書く必要があり、ボイラープレート化している。Issue #594 で Framework 側の根本修正が必要。`ErrorHandlerMiddleware` または `RequestValidationError` ハンドラーでサニタイズを一元化すれば、各 FT でのコピーが不要になる。
+
+**stdlib の設計思想を体系的に記録できている**  
+FT213〜FT218 の 6 件は「Python が持つ抽象化の各層」をカバーしている。abc が抽象化の定義、io がストリームの抽象化、struct がバイナリプロトコル、codecs がエンコーディング変換、csv / configparser がテキストフォーマット。FT ループが stdlib の地図を描いていると実感できる密度だった。
+
+**`Literal` 型 + Pydantic の組み合わせが成熟している**  
+FT215（struct フォーマット文字列）と FT216（codecs エンコーディング名）でいずれもホワイトリスト検証が自然に書けた。`Literal["utf-8", "ascii", ...]` の型制約が入力バリデーション・OpenAPI スキーマ生成・IDE 補完を一度に担う設計は、FT を重ねるほど洗練されている。
+
+### 積み残し課題の状況
+
+| 課題 | 状況 |
+|---|---|
+| Issue #539（handler response_model 統一） | 未対応・継続中 |
+| Issue #540（FT ループの目的明文化） | 未対応・継続中 |
+| Issue #541（PyPI 公開フロー） | 未対応・継続中 |
+| Issue #594（Infinity/NaN DoS 根本修正） | 各 FT でローカル対処中。Framework 修正は保留 |
+
+---
+
+## 明日以降の方針
+
+| 優先度 | Issue | タスク |
+|---|---|---|
+| 高 | — | FT219（219 % 3 = 0 → セキュリティ診断あり、219 % 4 = 3 → ペンテストなし）— テーマ候補: `argparse` |
+| 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | handler の response_model 統一（CLAUDE.md ポリシー準拠） |
+| 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | FT ループの目的・終着点を docs に明文化 |
+| 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | PyPI 公開フロー検証（uv publish） |
+| 中 | — | 並行系 how-to ガイド（FT188〜192 の知見まとめ） |
+| 低 | — | Issue #594: Infinity/NaN DoS を ErrorHandlerMiddleware で根本修正 |


### PR DESCRIPTION
## Summary

- 2026-05-23 の日報を `docs/review/2026-05-23.md` に追加
- FT213〜FT218（6 件）の完了記録、主な摩擦点、AI 所見を含む

🤖 Generated with [Claude Code](https://claude.com/claude-code)