### PR TITLE
chore: バージョンを v1.8.98 に更新（FT220 logging）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.97"
+version = "1.8.98"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.96"
+version = "1.8.98"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
FT220（logging）完了に合わせてパッチバージョンをインクリメント。

- `pyproject.toml`: 1.8.97 → 1.8.98
- `uv.lock`: self-version 同期（1.8.96 → 1.8.98。これまで lag していたものを是正）

関連: #614 / #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)