### PR TITLE
docs: FT221 tempfile — NamedTemporaryFile / mkstemp / TemporaryDirectory (#617)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-221.md
+++ b/docs/field-trials/2026-05-field-trial-221.md
@@ -1,0 +1,162 @@
+# FT221: tempfile — NamedTemporaryFile / mkstemp / TemporaryDirectory
+
+**日付**: 2026-05-29
+**テーマ**: Python `tempfile` モジュールの NamedTemporaryFile / mkstemp / TemporaryDirectory の実装と検証
+**セキュリティ診断**: なし（221 % 3 = 2）
+**クラッカーペンテスト**: なし（221 % 4 = 1）
+
+---
+
+## 概要
+
+`tempfile` は安全な一時ファイル・一時ディレクトリを生成する標準モジュール。HTTP API でラップし「内容を受け取り、一時ファイルに書いてメタデータを返す」パターンを検証した。一時ファイルは歴史的に **TOCTOU レースコンディション**（`mktemp`）と **予測可能なファイル名**による攻撃の温床であり、`tempfile` の「安全な API」と「危険な API」の境界を実装者目線で確かめることが本 FT の主眼。
+
+| API | ユースケース |
+|---|---|
+| `tempfile.NamedTemporaryFile()` | close 時に自動削除される名前付き一時ファイル |
+| `tempfile.mkstemp()` | fd とパスを返す低レベル API（close / unlink は呼び出し側責任） |
+| `tempfile.TemporaryDirectory()` | with 終了でディレクトリごと自動削除 |
+| `tempfile.mktemp()` | **非推奨**（TOCTOU 脆弱）。本 FT では使わない |
+
+---
+
+## 実装したサンプルアプリ
+
+**場所**: `/home/xi/docker/nene2-python-FT/ft221-tempfile/`
+
+### 主要機能
+
+| 関数 | 概要 |
+|---|---|
+| `write_named_tempfile()` | `NamedTemporaryFile` で書き込み、close 時に自動削除 |
+| `write_with_mkstemp()` | `mkstemp` で fd を取得し、`os.fdopen` + `try/finally` で close / unlink を明示管理 |
+| `use_temporary_directory()` | `TemporaryDirectory` 内にファイルを作り、with 終了で自動削除されることを確認 |
+| `_validate_affix()` | prefix / suffix / filename のパス区切り・null バイト・`..` を拒否 |
+| `_mode_octal()` | 作成ファイルのパーミッションを 8 進文字列で取得 |
+
+### エンドポイント
+
+| メソッド | パス | 概要 |
+|---|---|---|
+| POST | `/tempfile/named` | NamedTemporaryFile で書き込み |
+| POST | `/tempfile/mkstemp` | mkstemp で書き込み（prefix / suffix 指定可） |
+| POST | `/tempfile/directory` | TemporaryDirectory 内にファイル作成 |
+
+---
+
+## 摩擦点
+
+### F-1: `mkstemp` は prefix / suffix をサニタイズしない（パストラバーサル）
+
+**観察**: `tempfile.mkstemp(suffix=...)` は suffix を**生成パスに直接連結**する。`suffix="../../etc/passwd"` を渡すと内部的に `/tmp/tmpXXXXXX../../etc/passwd` というパスになり、**一時ディレクトリの外**を指す。今回の検証環境では中間ディレクトリが存在せず `FileNotFoundError` になったが、**書き込み先のディレクトリが存在すれば一時ディレクトリ外へファイルを生成できてしまう**。`tempfile` 自身はこの検証を行わない。
+
+```python
+>>> tempfile.mkstemp(suffix="../../etc/passwd")
+FileNotFoundError: [Errno 2] ... '/tmp/tmpwk_cpt59../../etc/passwd'
+```
+
+**対処**: ユーザー由来の prefix / suffix / filename は `_validate_affix()` で `os.sep` / `os.altsep` / `\x00` / `..` を含む場合に `ValueError` を投げ、422 で遮断する。`tempfile` に渡る前にアプリ側で防ぐのが鉄則。
+
+```python
+_FORBIDDEN_AFFIX = tuple(t for t in (os.sep, os.altsep, "\x00", "..") if t)
+```
+
+---
+
+### F-2: `mkstemp` は fd を返すだけ — close / unlink が呼び出し側責任
+
+**観察**: `mkstemp()` は `(fd, path)` を返す低レベル API で、`NamedTemporaryFile` と違い**自動クローズも自動削除もしない**。fd を閉じ忘れるとファイルディスクリプタリークになり、unlink を忘れると `/tmp` にゴミが残り続ける（長期稼働でディスク枯渇 DoS の温床）。
+
+**対処**: fd は `os.fdopen(fd, ...)` で file object に包み `with` で確実にクローズし、パスの削除は `try/finally` で `path.unlink(missing_ok=True)` を必ず実行する。
+
+```python
+fd, raw_path = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+path = Path(raw_path)
+try:
+    with os.fdopen(fd, "w+") as handle:  # fd の所有権を渡し with でクローズ
+        ...
+finally:
+    path.unlink(missing_ok=True)         # mkstemp は自動削除しない
+```
+
+---
+
+### F-3: 安全な API でもパーミッションは確認すべき（0o600）
+
+**観察**: `tempfile` の安全な API（`NamedTemporaryFile` / `mkstemp`）はファイルを **`0o600`（オーナーのみ読み書き可）** で生成する。これは設計上の保証だが、レビュー時に「本当にその権限か」を確認する習慣がないと、`os.open` を手書きした箇所で `0o644` を作ってしまう事故に気付けない。
+
+**対処**: レスポンスに `mode`（`oct(stat.S_IMODE(...))`）を含め、テストで `mode == "0o600"` を回帰検証する。`NamedTemporaryFile` / `mkstemp` 双方で `0o600` を確認した。
+
+---
+
+## テスト結果
+
+```
+10 passed in 0.91s
+```
+
+`pytest`, `mypy --strict`, `ruff check`, `ruff format --check`, `pip-audit` すべて通過。
+
+主要なテスト観点:
+- `mode == "0o600"`（NamedTemporaryFile / mkstemp の両方）
+- `name` がベース名のみ（絶対パス非公開）
+- suffix の `../../etc/passwd` → 422
+- prefix の null バイト → 422
+- filename の `../escape.txt` → 422
+- TemporaryDirectory の `removed_after_exit is True`（自動削除）
+
+---
+
+## DX Review — 6 ペルソナ
+
+### 1. 初心者（Python 歴1年・独学中・女性・バックエンド志望）
+
+「一時ファイルを作って読み書きして返す」という流れは理解しやすい。`NamedTemporaryFile` を `with` で使う形は他のファイル操作と同じなので入りやすい。
+
+**ドキュメント理解**: `mkstemp` が fd（整数）を返す点は初見で戸惑う。`os.fdopen` で包む必要性の説明が要る。
+**事故リスク（高）**: `mktemp`（末尾に p が無い方）をネットのサンプルからコピペすると TOCTOU 脆弱性を持ち込む。名前が 1 文字違いで紛らわしい。
+**規約の使いやすさ**: `content` を送れば `mode` / `size` / `name` が返る形は素直。
+
+### 2. ロースキル経験者（Python 歴3-4年・スクリプト系・男性・SES）
+
+アップロードファイルの一時保管やバッチの中間ファイルで `tempfile` を使う場面は多い。`mkstemp` の `try/finally` 削除パターンはコピペで流用できる。
+
+**コピペ可能性**: `write_with_mkstemp()` の fd 管理＋ unlink は実務でそのまま使える完成度。
+**拡張時の罠**: ユーザー入力を prefix / suffix にそのまま渡してパストラバーサル（F-1）を作り込みやすい。`_validate_affix` を省略すると危険。
+**事故リスク（中）**: unlink 忘れによる `/tmp` のゴミ蓄積。
+
+### 3. フロントエンド寄り（React/TS 歴4年・バックエンド転向中・ノンバイナリ）
+
+Node の `os.tmpdir()` / `fs.mkdtemp()` と概念が対応するので理解しやすい。一時ファイルが自動削除される点は Node より親切に感じる。
+
+**エラーレスポンスの質**: 不正な suffix / filename は 422 で `{field, message, code}` が返り扱いやすい。
+**Python 固有概念の学習コスト**: ファイルパーミッション（`0o600`）の概念は Unix 文脈で、フロント出身者には新鮮。`mode` をレスポンスに含めると学習の助けになる。
+**事故リスク（低）**: 入力は Pydantic と `_validate_affix` で二重に制限。
+
+### 4. バックエンド経験者（Django/FastAPI 歴5-6年・男性・リードエンジニア）
+
+`tempfile` の安全/危険 API の境界は周知。`mkstemp` + `try/finally` は王道。`TemporaryDirectory` の自動クリーンアップを `removed_after_exit` で明示検証している点が良い。
+
+**他フレームワークとの差異**: Django の `FileSystemStorage` や `NamedTemporaryFile` 直叩きと同じ。フレームワーク横断で `mktemp` 禁止・affix 検証は共通の注意点。
+**nene2 の薄さへの評価**: tempfile を HTTP でラップする薄い層として適切。パス検証だけアプリ側に寄せる設計は妥当。
+**事故リスク（低）**: パストラバーサル・パーミッションともテストで担保。
+
+### 5. シニアエンジニア（設計・コードレビュー担当・女性・10-12年）
+
+**コードレビューチェックポイント**:
+- `mktemp()`（末尾 p 無し）を使っていないか — TOCTOU 脆弱。`mkstemp` / `NamedTemporaryFile` を使う。
+- ユーザー入力を prefix / suffix / dir に直接渡していないか — パストラバーサル（F-1）。affix 検証必須。
+- `mkstemp` の fd を `with`/`finally` でクローズし、パスを unlink しているか — リーク・ゴミ防止。
+- 生成ファイルのパーミッションが `0o600` か — `os.open` を手書きした場合は特に確認。
+- 絶対パスをレスポンスやログに出していないか — `/tmp` 構造の情報漏洩。本 FT は `name`（ベース名）のみ返す。
+
+**チームでの安全なパターン**: `_validate_affix` を共通ユーティリティ化し、tempfile を使う全箇所で強制する。
+**事故リスク（低）**: 摩擦点 F-1〜F-3 が明示され回帰テスト済み。
+
+### 6. 設計者（nene2-python 設計ポリシー目線）
+
+**CLAUDE.md ポリシー整合性**: `pathlib.Path` でのパス操作（`os.path.*` 不使用）・Pydantic 長さ制限・`ValidationException` 変換・`logging` 使用はすべて準拠。パストラバーサル防御は「ファイルパスは `pathlib.Path` で操作しパストラバーサルを防ぐ」ポリシーの実践例。
+**初心者でも安全な API 達成度**: `_validate_affix` でユーザー affix を遮断し、`mkstemp` の fd / unlink を `with` / `finally` で隠蔽することで、初心者が `mktemp` やリークを書く余地を最小化できている。
+**改善提案**:
+- `_validate_affix` は `nene2.http` か `nene2` のパスユーティリティに昇格し、ファイル名・アップロード名検証で再利用する価値がある。
+- how-to に「`mktemp` 禁止 / affix 検証 / `mkstemp` の fd・unlink 管理」を 1 本まとめると、tempfile を使う実装者の事故を減らせる。

--- a/docs/field-trials/INDEX.md
+++ b/docs/field-trials/INDEX.md
@@ -254,6 +254,7 @@
 | [FT218](2026-05-field-trial-218.md) | configparser モジュール — read / write / sections / interpolation | | |
 | [FT219](2026-05-field-trial-219.md) | argparse モジュール — ArgumentParser / add_argument / parse_args / subcommands | 🔒 | |
 | [FT220](2026-05-field-trial-220.md) | logging モジュール — Logger / Handler / Formatter / Filter | 🔍 | |
+| [FT221](2026-05-field-trial-221.md) | tempfile モジュール — NamedTemporaryFile / mkstemp / TemporaryDirectory | | |
 
 ---
 
@@ -269,4 +270,4 @@ FT172, FT176, FT180, FT184, FT188, FT192, FT196, FT200, FT204, FT208, FT212, FT2
 
 ---
 
-*最終更新: 2026-05-29 (FT220 / v1.8.98)*
+*最終更新: 2026-05-29 (FT221 / v1.8.99)*

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,18 +1,17 @@
 # TODO — current
 
 最終更新: 2026-05-29
-現状: **v1.8.98 / FT220（logging）完了 / CI グリーン**
+現状: **v1.8.99 / FT221（tempfile）完了 / CI グリーン**
 
 ---
 
 ## 状態サマリー
 
-FT220（logging — Logger / Handler / Formatter / Filter）完了。
-セキュリティ診断なし（220 % 3 = 1）、**クラッカーペンテストあり（220 % 4 = 0）**。
-フォーマット文字列インジェクション（`logger.info(user_input)` の罠）・CRLF ログ偽造・機密秘匿 Filter を検証。
-ペンテスト 18 攻撃中 17 防御、D3（JSON 埋め込み秘匿漏れ）のみ LOW として記録（redaction は多層防御の補助、主防御は `SecretStr`）。
-ruff `LOG001` を契機に「`getLogger` + リクエストごと Handler attach/detach（contextmanager + try/finally）」パターンを確立。
-**サンドボックス 11 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT221 以降も継続中。
+FT221（tempfile — NamedTemporaryFile / mkstemp / TemporaryDirectory）完了。
+セキュリティ診断なし（221 % 3 = 2）、クラッカーペンテストなし（221 % 4 = 1）。
+`mkstemp` が prefix/suffix をサニタイズせず生成パスに直連結する点（パストラバーサル）を発見 → `_validate_affix` で `os.sep`/`..`/null バイトを遮断。
+`mkstemp` の fd は `os.fdopen` + `with`、パスは `try/finally` で `unlink`。安全な API は `0o600` で生成されることをテスト回帰化。
+**サンドボックス 10 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT222 以降も継続中。
 
 ---
 
@@ -36,6 +35,7 @@ ruff `LOG001` を契機に「`getLogger` + リクエストごと Handler attach/
 
 | バージョン | 主な内容 |
 |---|---|
+| v1.8.99 | FT221: tempfile — NamedTemporaryFile / mkstemp / TemporaryDirectory（affix 検証・0o600）|
 | v1.8.98 | FT220: logging — Logger / Handler / Formatter / Filter（クラッカーペンテスト合格）|
 | v1.8.97 | docs: README / roadmap / reference を v1.8.96 現状に同期、starlette CVE 解消反映 |
 | v1.8.96 | FT219: argparse — ArgumentParser / add_argument / parse_args / subcommands（セキュリティ診断合格）|
@@ -66,13 +66,13 @@ ruff `LOG001` を契機に「`getLogger` + リクエストごと Handler attach/
 
 ## フィールドトライアル進捗
 
-**実施済み**: FT1〜FT220（全 220 件）
+**実施済み**: FT1〜FT221（全 221 件）
 
 索引: [`docs/field-trials/INDEX.md`](../field-trials/INDEX.md)
 
 **次のアクション**:
-- FT221 を開始（221 % 3 = 2 → セキュリティ診断なし、221 % 4 = 1 → クラッカーペンテストなし）
-- テーマ候補: `tempfile` モジュール（NamedTemporaryFile / mkstemp / TemporaryDirectory / セキュアなパーミッション）
+- FT222 を開始（222 % 3 = 0 → **セキュリティ診断あり**、222 % 4 = 2 → クラッカーペンテストなし）
+- テーマ候補: `hashlib` モジュール（sha256 / pbkdf2_hmac / blake2 / パスワードハッシュ・タイミング攻撃）
 
 ---
 
@@ -80,7 +80,7 @@ ruff `LOG001` を契機に「`getLogger` + リクエストごと Handler attach/
 
 | 優先度 | Issue | タスク | 種別 |
 |---|---|---|---|
-| 高 | — | FT221 実施（tempfile、診断・ペンテストなし） | FT |
+| 高 | — | FT222 実施（hashlib、セキュリティ診断あり） | FT |
 | 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | handler の response_model 統一 | enhancement |
 | 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | FT ループの目的・終着点を明文化 | docs |
 | 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | PyPI 公開フロー検証（uv publish） | enhancement |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.98"
+version = "1.8.99"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.98"
+version = "1.8.99"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 概要

フィールドトライアル **FT221**: Python 標準 `tempfile` モジュール（NamedTemporaryFile / mkstemp / TemporaryDirectory）を nene2-python 上で実装・検証。

- セキュリティ診断: なし（221 % 3 = 2）
- クラッカーペンテスト: なし（221 % 4 = 1）

サンドボックス: `nene2-python-FT/ft221-tempfile/`（main リポジトリ外。本 PR には FT レポート・docs 同期・バージョン bump を含む）

## 摩擦点

| # | 内容 |
|---|---|
| F-1 | `mkstemp` は prefix/suffix をサニタイズせず生成パスに直連結 → `suffix="../../etc/passwd"` でパストラバーサル可能。`_validate_affix` で `os.sep`/`..`/null バイトを遮断 |
| F-2 | `mkstemp` は fd を返すだけで自動クローズ/削除なし → `os.fdopen` + `with`、`try/finally` で `unlink` |
| F-3 | 安全な API でも `0o600` 生成をレビュー・テストで確認すべき |

## チェック

- サンドボックス: `pytest`(10 passed) / `mypy --strict` / `ruff check` / `ruff format --check` / `pip-audit` 全通過
- フレームワーク本体テスト(466)に影響なし（docs + バージョン bump のみ）

## 変更ファイル

- `docs/field-trials/2026-05-field-trial-221.md`（新規）
- `docs/field-trials/INDEX.md`（FT221 行）
- `docs/todo/current.md`（v1.8.99 / 次タスク FT222 hashlib）
- `pyproject.toml` / `uv.lock`（1.8.98 → 1.8.99）

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)