### PR TITLE
docs: FT233 textwrap (#641)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-233.md
+++ b/docs/field-trials/2026-05-field-trial-233.md
@@ -1,0 +1,121 @@
+# FT233: textwrap — wrap / fill / shorten / indent
+
+**日付**: 2026-05-29
+**テーマ**: Python `textwrap` モジュールのテキスト整形の実装と検証
+**セキュリティ診断**: なし（233 % 3 = 2）
+**クラッカーペンテスト**: なし（233 % 4 = 1）
+
+---
+
+## 概要
+
+`textwrap` はテキストの折り返し・省略・インデントを提供する。HTTP API でラップし wrap / shorten / indent を検証した。CLI 出力やメール本文整形で頻出のユーティリティ。
+
+| API | ユースケース |
+|---|---|
+| `textwrap.wrap(text, width)` | width で折り返し行リスト |
+| `textwrap.shorten(text, width, placeholder)` | width に収め超過を省略 |
+| `textwrap.indent(text, prefix)` | 各行に prefix 付与 |
+
+---
+
+## 実装したサンプルアプリ
+
+**場所**: `/home/xi/docker/nene2-python-FT/ft233-textwrap/`
+
+| 関数 | 概要 |
+|---|---|
+| `wrap_text()` | `break_long_words=True`（既定）で長語も強制分割 |
+| `shorten_text()` | placeholder `" …"` で省略 |
+| `indent_text()` | prefix 付与（空行には付けない既定） |
+
+| メソッド | パス | 概要 |
+|---|---|---|
+| POST | `/text/wrap` | 折り返し |
+| POST | `/text/shorten` | 省略 |
+| POST | `/text/indent` | インデント |
+
+---
+
+## 摩擦点
+
+### F-1: `wrap` の `break_long_words` 既定 True — width 超過の単語も分割される
+
+**観察**: `width` を超える 1 単語（URL や長い識別子など）は、既定（`break_long_words=True`）では**強制的に分割**される。`False` にすると width を超えた行がそのまま残り、レイアウトが崩れる。
+
+**対処**: 既定の `break_long_words=True` を維持し、`x`×20 を width 5 で折っても全行 ≤5 になることをテストで確認。
+
+### F-2: `shorten` は空白を畳んでから width に収める
+
+**観察**: `shorten` は内部で**連続する空白を 1 つに正規化**してから width に収める。元のスペースを保ちたい用途には不向き。また placeholder（既定 `" [...]"`）の長さも width に含まれるため、極端に小さい width だと `ValueError`。
+
+**対処**: placeholder を `" …"` に。短いテキストはそのまま返ることを確認。
+
+### F-3: `indent` は空行に prefix を付けない（既定の predicate）
+
+**観察**: `textwrap.indent(text, prefix)` の既定 predicate は「空白のみの行には prefix を付けない」。意図せず空行に prefix を付けたい場合は predicate を渡す必要がある。
+
+**対処**: 既定挙動（空行は素通り）を採用。`"a\nb"` → `">> a\n>> b"` を確認。
+
+---
+
+## テスト結果
+
+```
+7 passed in 0.85s
+```
+
+`pytest`, `mypy --strict`, `ruff check`, `ruff format --check`, `pip-audit` すべて通過。
+
+---
+
+## DX Review — 6 ペルソナ
+
+### 1. 初心者（Python 歴1年・独学中・女性・バックエンド志望）
+
+折り返し・省略・インデントは直感的。結果が目に見えて変わるので学びやすい。
+
+**ドキュメント理解**: `break_long_words`・`shorten` の空白畳みは説明が要る。
+**事故リスク（低）**: 破壊的操作なし。
+**規約の使いやすさ**: text + width が分かりやすい。
+
+### 2. ロースキル経験者（Python 歴3-4年・スクリプト系・男性・SES）
+
+ログやレポートの整形に便利。`shorten` の空白畳みで「あれ？」となりがち。
+
+**コピペ可能性**: 3 関数とも流用可。
+**拡張時の罠**: `shorten` の空白正規化、`indent` の空行スキップ。
+**事故リスク（低）**: 入力長・width 制限あり。
+
+### 3. フロントエンド寄り（React/TS 歴4年・バックエンド転向中・ノンバイナリ）
+
+CSS の `text-overflow: ellipsis` に相当する処理をサーバー側でやる感覚。
+
+**エラーレスポンスの質**: width 範囲外は 422。
+**Python 固有概念**: `textwrap` の各種オプション。
+**事故リスク（低）**: 制限あり。
+
+### 4. バックエンド経験者（Django/FastAPI 歴5-6年・男性・リードエンジニア）
+
+CLI ヘルプ生成（argparse FT219 と併用）やメール整形で使う。マルチバイト幅（東アジア文字）は `textwrap` が考慮しない点に注意。
+
+**他フレームワークとの差異**: 全角幅を厳密に扱うなら `wcwidth` 併用が必要。
+**nene2 の薄さへの評価**: 薄いラップとして妥当。
+**事故リスク（低）**: 制限あり。
+
+### 5. シニアエンジニア（設計・コードレビュー担当・女性・10-12年）
+
+**コードレビューチェックポイント**:
+- `width` に範囲制限があるか（極小 width での `shorten` 例外）。
+- `shorten` の空白正規化を理解した上で使っているか。
+- 全角文字の表示幅を考慮する必要がないか（`textwrap` は文字数ベース）。
+- 入力長上限（巨大テキストの整形コスト）。
+
+**チームでの安全なパターン**: 表示幅が重要な箇所は `wcwidth` 併用を明記。
+**事故リスク（低）**: width/長さ制限を回帰化。
+
+### 6. 設計者（nene2-python 設計ポリシー目線）
+
+**CLAUDE.md ポリシー整合性**: Pydantic 範囲/長さ制限・`ValidationException` 変換・`logging` 使用は準拠。
+**初心者でも安全な API 達成度**: width 範囲・break_long_words を関数内に固定し、行溢れ・例外の余地を抑制。
+**改善提案**: 全角幅を扱う場合の `wcwidth` 併用を how-to に補足する。

--- a/docs/field-trials/INDEX.md
+++ b/docs/field-trials/INDEX.md
@@ -266,6 +266,7 @@
 | [FT230](2026-05-field-trial-230.md) | difflib モジュール — unified_diff / SequenceMatcher / get_close_matches |  | |
 | [FT231](2026-05-field-trial-231.md) | shlex モジュール — split / quote / join（シェルインジェクション対策） | 🔒 | |
 | [FT232](2026-05-field-trial-232.md) | fnmatch モジュール — fnmatch / filter / translate | 🔍 | |
+| [FT233](2026-05-field-trial-233.md) | textwrap モジュール — wrap / fill / shorten / indent |  | |
 
 ---
 
@@ -281,4 +282,4 @@ FT172, FT176, FT180, FT184, FT188, FT192, FT196, FT200, FT204, FT208, FT212, FT2
 
 ---
 
-*最終更新: 2026-05-29 (FT232 / v1.8.110)*
+*最終更新: 2026-05-29 (FT233 / v1.8.111)*

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,16 +1,16 @@
 # TODO — current
 
 最終更新: 2026-05-29
-現状: **v1.8.110 / FT232（fnmatch）完了 / CI グリーン**
+現状: **v1.8.111 / FT233（textwrap）完了 / CI グリーン**
 
 ---
 
 ## 状態サマリー
 
-FT232（fnmatch — fnmatch / filter / translate）完了。診断なし（232 % 3 = 1）・**クラッカーペンテストあり（232 % 4 = 0）合格**。
-`fnmatch` は OS により大小区別が変わるため `fnmatchcase` で決定化。ワイルドカード数を 20 に上限化。
-ペンテスト: 上限内でも最悪 6ms（ReDoS なし）、`translate` は glob 以外の正規表現メタ文字をエスケープし regex 注入不可。全攻撃防御。
-**サンドボックス 7 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT233 以降も継続中。
+FT233（textwrap — wrap / fill / shorten / indent）完了。診断なし（233 % 3 = 2）・ペンテストなし（233 % 4 = 1）。
+`wrap` の `break_long_words=True`（既定）で width 超過の単語も強制分割し行溢れを防止。`shorten` は空白を畳んでから width に収める点に注意。
+`indent` は空行に prefix を付けない既定挙動。width は 1〜500 に制限。全角幅は文字数ベースのため `wcwidth` 併用を補足。
+**サンドボックス 7 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT234 以降も継続中。
 
 ---
 
@@ -34,6 +34,7 @@ FT232（fnmatch — fnmatch / filter / translate）完了。診断なし（232 %
 
 | バージョン | 主な内容 |
 |---|---|
+| v1.8.111 | FT233: textwrap — wrap / fill / shorten / indent（width 制限・長語分割） |
 | v1.8.110 | FT232: fnmatch — fnmatch / filter / translate（クラッカーペンテスト合格） |
 | v1.8.109 | FT231: shlex — split / quote / join（セキュリティ診断合格・シェルインジェクション中和） |
 | v1.8.108 | FT230: difflib — unified_diff / SequenceMatcher / get_close_matches（O(n^2) 入力制限） |
@@ -76,13 +77,13 @@ FT232（fnmatch — fnmatch / filter / translate）完了。診断なし（232 %
 
 ## フィールドトライアル進捗
 
-**実施済み**: FT1〜FT232（全 232 件）
+**実施済み**: FT1〜FT233（全 233 件）
 
 索引: [`docs/field-trials/INDEX.md`](../field-trials/INDEX.md)
 
 **次のアクション**:
-- FT233 を開始（233 % 3 = 2 → セキュリティ診断なし、233 % 4 = 1 → クラッカーペンテストなし）
-- テーマ候補: `textwrap` モジュール（wrap / fill / shorten / indent）
+- FT234 を開始（234 % 3 = 0 → **セキュリティ診断あり**、234 % 4 = 2 → クラッカーペンテストなし）
+- テーマ候補: `ipaddress` モジュール（ip_address / ip_network / is_private・SSRF/プライベート範囲）
 
 ---
 
@@ -90,7 +91,7 @@ FT232（fnmatch — fnmatch / filter / translate）完了。診断なし（232 %
 
 | 優先度 | Issue | タスク | 種別 |
 |---|---|---|---|
-| 高 | — | FT233 実施（textwrap、診断・ペンテストなし） | FT |
+| 高 | — | FT234 実施（ipaddress、セキュリティ診断あり） | FT |
 | 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | handler の response_model 統一 | enhancement |
 | 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | FT ループの目的・終着点を明文化 | docs |
 | 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | PyPI 公開フロー検証（uv publish） | enhancement |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.110"
+version = "1.8.111"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.110"
+version = "1.8.111"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
FT233: textwrap。break_long_words で行溢れ防止、shorten の空白畳み、width 制限。サンドボックス 7 tests。v1.8.111。

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)