### PR TITLE
docs: FT278 string (#731)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-278.md
+++ b/docs/field-trials/2026-05-field-trial-278.md
@@ -1,0 +1,118 @@
+# FT278: string — capwords / 定数（文字種判定）
+
+**日付**: 2026-05-29
+**テーマ**: Python `string` モジュールの定数・capwords の実装と検証
+**セキュリティ診断**: なし（278 % 3 = 2）
+**クラッカーペンテスト**: なし（278 % 4 = 1）
+
+---
+
+## 概要
+
+`string` モジュールは文字集合の定数（`ascii_letters`/`digits`/`punctuation`/`printable`）と `capwords` を提供する。HTTP API でラップし単語の大文字化と ASCII 文字種判定を検証した。FT236（Template）/FT248（Formatter）は string のサブ機能で、本 FT は定数と capwords に焦点を当てる。
+
+| API | ユースケース |
+|---|---|
+| `string.capwords(s)` | 単語の先頭を大文字化 |
+| `string.ascii_letters` / `digits` / `punctuation` / `printable` | 文字集合定数 |
+
+---
+
+## 実装したサンプルアプリ
+
+**場所**: `/home/xi/docker/nene2-python-FT/ft278-string/`
+
+| 関数 | 概要 |
+|---|---|
+| `capwords_text()` | `string.capwords` で各単語を大文字化 |
+| `classify_charset()` | string 定数で ASCII 文字種を判定 |
+
+| メソッド | パス | 概要 |
+|---|---|---|
+| POST | `/string/capwords` | 単語の先頭を大文字化 |
+| POST | `/string/charset` | 文字種判定 |
+
+---
+
+## 摩擦点
+
+### F-1: `capwords` は空白を畳む
+
+**観察**: `string.capwords("a   b")` は `"A B"`（連続空白が 1 つに）。`str.title()` とは挙動が異なる（title はアポストロフィ等で誤動作する）。元の空白を保ちたい場合は不向き。
+
+**対処**: capwords の空白畳み挙動を理解して使う。`"a   b"`→`"A B"` を確認。
+
+### F-2: string 定数は ASCII 限定（ロケール非依存）
+
+**観察**: `string.ascii_letters` は `a-zA-Z` のみで、ロケールに依存しない（昔の `string.letters` はロケール依存だった）。日本語等は含まれない。ASCII 限定の文字種チェックに適する。
+
+**対処**: 集合演算（`set(text) <= _ASCII_ALNUM`）で ASCII 英数字のみか判定。日本語は `is_ascii_alnum=False`。ロケール非依存で安定。
+
+### F-3: 文字種判定をセキュリティに使う場合
+
+**観察**: ASCII 英数字のみの許可は、識別子・ファイル名・トークンの厳格化に使える（homoglyph FT246 の ASCII 限定対策とも整合）。ただし正当な非 ASCII 入力を弾く点に注意。
+
+**対処**: 用途に応じて ASCII 限定を選択。本 FT は判定のみを提供。
+
+---
+
+## テスト結果
+
+```
+6 passed in 0.86s
+```
+
+`pytest`, `mypy --strict`, `ruff check`, `ruff format --check`, `pip-audit` すべて通過。
+
+---
+
+## DX Review — 6 ペルソナ
+
+### 1. 初心者（Python 歴1年・独学中・女性・バックエンド志望）
+
+capwords は便利だが空白畳みは意外。string 定数は文字種チェックに使える。
+
+**ドキュメント理解**: capwords の空白畳みをコメントで明示。
+**事故リスク（低）**: 文字列処理のみ。
+**規約の使いやすさ**: text → 結果が分かりやすい。
+
+### 2. ロースキル経験者（Python 歴3-4年・スクリプト系・男性・SES）
+
+入力サニタイズで文字種チェックに使う。title() の罠を避け capwords を選べる。
+
+**コピペ可能性**: classify_charset は流用可。
+**拡張時の罠**: capwords の空白畳み・title との違い。
+**事故リスク（低）**: ASCII 限定の理解。
+
+### 3. フロントエンド寄り（React/TS 歴4年・バックエンド転向中・ノンバイナリ）
+
+文字クラス（`/[a-z0-9]/`）の発想と一致。ロケール非依存は安心。
+
+**エラーレスポンスの質**: 空は 422。
+**Python 固有概念**: string 定数・capwords。
+**事故リスク（低）**: 判定あり。
+
+### 4. バックエンド経験者（Django/FastAPI 歴5-6年・男性・リードエンジニア）
+
+ASCII 限定の文字種チェックは識別子・トークン検証で有用。homoglyph 対策（FT246）の ASCII 限定とも整合。
+
+**他フレームワークとの差異**: 正規表現でも同等。string 定数は明示的。
+**nene2 の薄さへの評価**: 集合演算による判定が明快。
+**事故リスク（低）**: 判定のみ。
+
+### 5. シニアエンジニア（設計・コードレビュー担当・女性・10-12年）
+
+**コードレビューチェックポイント**:
+- `str.title()` の誤動作を避け capwords/明示処理を使っているか。
+- ASCII 限定チェックが正当な非 ASCII を不当に弾いていないか。
+- 文字種チェックを homoglyph 対策（FT246）と組み合わせているか。
+- 長さ上限。
+
+**チームでの安全なパターン**: ASCII 限定は高セキュリティ識別子のみ、一般入力は NFKC + カテゴリ（FT246）。
+**事故リスク（低）**: 判定を回帰化。
+
+### 6. 設計者（nene2-python 設計ポリシー目線）
+
+**CLAUDE.md ポリシー整合性**: Pydantic 制限・`ValidationException` 変換・`logging` 使用は準拠。
+**初心者でも安全な API 達成度**: ロケール非依存の ASCII 判定を提供。
+**改善提案**: 文字種判定（本 FT）と NFKC/カテゴリ（FT246）の使い分けを how-to に統合する。

--- a/docs/field-trials/INDEX.md
+++ b/docs/field-trials/INDEX.md
@@ -311,6 +311,7 @@
 | [FT275](2026-05-field-trial-275.md) | cmath モジュール — 複素数演算 / 極座標変換 |  | |
 | [FT276](2026-05-field-trial-276.md) | subprocess — 安全なコマンド実行 | 🔒🔍 | |
 | [FT277](2026-05-field-trial-277.md) | keyword モジュール — iskeyword / issoftkeyword / 識別子検証 |  | |
+| [FT278](2026-05-field-trial-278.md) | string モジュール — capwords / 定数（文字種判定） |  | |
 
 ---
 
@@ -326,4 +327,4 @@ FT172, FT176, FT180, FT184, FT188, FT192, FT196, FT200, FT204, FT208, FT212, FT2
 
 ---
 
-*最終更新: 2026-05-29 (FT277 / v1.8.155)*
+*最終更新: 2026-05-29 (FT278 / v1.8.156)*

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,16 +1,16 @@
 # TODO — current
 
 最終更新: 2026-05-29
-現状: **v1.8.155 / FT277（keyword）完了 / CI グリーン**
+現状: **v1.8.156 / FT278（string）完了 / CI グリーン**
 
 ---
 
 ## 状態サマリー
 
-FT277（keyword — iskeyword / issoftkeyword）完了。診断なし（277 % 3 = 1）・ペンテストなし（277 % 4 = 1）。
-`str.isidentifier` は予約語も True にするため `isidentifier() and not iskeyword()` で安全な識別子を判定。
-ソフトキーワード（match/case/type/_）は変数名として使えるため別途 issoftkeyword で判定。動的属性アクセスの前の名前検証に有用。
-**サンドボックス 5 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT278 以降も継続中。
+FT278（string — capwords / 定数）完了。診断なし（278 % 3 = 2）・ペンテストなし（278 % 4 = 1）。
+`capwords` は空白を畳む（title() の誤動作を回避）。string 定数（ascii_letters/digits/punctuation）はロケール非依存の ASCII 限定で文字種判定に適する。
+集合演算で ASCII 英数字判定。homoglyph 対策（FT246）の ASCII 限定とも整合。
+**サンドボックス 6 tests**、フレームワーク本体 466 tests 据え置き。フィールドトライアルループは FT279 以降も継続中。
 
 ---
 
@@ -34,6 +34,7 @@ FT277（keyword — iskeyword / issoftkeyword）完了。診断なし（277 % 3 
 
 | バージョン | 主な内容 |
 |---|---|
+| v1.8.156 | FT278: string — capwords / 定数（ASCII 文字種判定） |
 | v1.8.155 | FT277: keyword — iskeyword / issoftkeyword（安全な識別子検証） |
 | v1.8.154 | FT276: subprocess — 安全なコマンド実行（診断＋ペンテスト合格） |
 | v1.8.153 | FT275: cmath — 複素数演算 / 極座標（isfinite ガード・real/imag 分離） |
@@ -121,13 +122,13 @@ FT277（keyword — iskeyword / issoftkeyword）完了。診断なし（277 % 3 
 
 ## フィールドトライアル進捗
 
-**実施済み**: FT1〜FT277（全 277 件）
+**実施済み**: FT1〜FT278（全 278 件）
 
 索引: [`docs/field-trials/INDEX.md`](../field-trials/INDEX.md)
 
 **次のアクション**:
-- FT278 を開始（278 % 3 = 2 → セキュリティ診断なし、278 % 4 = 2 → クラッカーペンテストなし）
-- テーマ候補: `string` モジュール（capwords / 定数）
+- FT279 を開始（279 % 3 = 0 → **セキュリティ診断あり**、279 % 4 = 3 → クラッカーペンテストなし）
+- テーマ候補: `plistlib` モジュール（plist 解析の安全性・サイズ制限）
 
 ---
 
@@ -135,7 +136,7 @@ FT277（keyword — iskeyword / issoftkeyword）完了。診断なし（277 % 3 
 
 | 優先度 | Issue | タスク | 種別 |
 |---|---|---|---|
-| 高 | — | FT278 実施（string、診断・ペンテストなし） | FT |
+| 高 | — | FT279 実施（plistlib、セキュリティ診断あり） | FT |
 | 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | handler の response_model 統一 | enhancement |
 | 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | FT ループの目的・終着点を明文化 | docs |
 | 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | PyPI 公開フロー検証（uv publish） | enhancement |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.155"
+version = "1.8.156"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.155"
+version = "1.8.156"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
FT278: string。capwords の空白畳み、ロケール非依存 ASCII 文字種判定。サンドボックス 6 tests。v1.8.156。

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)