### PR TITLE
fix: handler の response_model 統一（#539）

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,16 +1,17 @@
 # TODO — current
 
 最終更新: 2026-05-29
-現状: **v1.8.160 / FT282（platform）完了 / CI グリーン**
+現状: **v1.8.161 / #539（response_model 統一）解消 / CI グリーン**
 
 ---
 
 ## 状態サマリー
 
-FT282（platform — システム情報を露出しない）完了。**セキュリティ診断あり（282 % 3 = 0）合格**・ペンテストなし（282 % 4 = 2）。
-詳細システム情報（hostname/python version/OS release/platform()/machine）を API レスポンスに含めず内部ログのみ。公開は `{healthy, os_family}` の非機微情報だけ。
-フィンガープリント・CVE 標的化を助ける情報漏洩を防止。スタックトレース非公開（CLAUDE.md）と同思想。
-**サンドボックス 5 tests**、フレームワーク本体 466 tests 据え置き。FT263〜FT282 の 20 本連続フィールドトライアルを完走。
+#539 を解消（v1.8.161）。Note/Tag/Comment の全ハンドラーが `JSONResponse` 直返しで `response_model` を使っておらず CLAUDE.md ポリシー（「レスポンスモデルを response_model で明示」）に違反していた問題を修正。
+各ドメインに `XxxResponse` / `XxxListResponse`（Pydantic）を定義し `@router.xxx(..., response_model=...)` と戻り値型を明示。OpenAPI に 6 レスポンススキーマ（Note/Tag/Comment × 単体/一覧）が出力され、各ルートが `$ref` で参照することを確認。
+ハンドラーは「parse → use-case → response」の薄さを維持（バリデーションは `_validate_*` に抽出）。**フレームワーク本体 466 tests 据え置き・カバレッジ 93.5%**。
+ハウスキーピング: FT サンドボックスを 5.1G→79M に整理、マージ済み orphan ブランチ 8 本を削除。
+FT ループは FT283（gettext）以降も継続可能。
 
 ---
 
@@ -34,6 +35,7 @@ FT282（platform — システム情報を露出しない）完了。**セキュ
 
 | バージョン | 主な内容 |
 |---|---|
+| v1.8.161 | fix: handler の response_model 統一（#539）— Note/Tag/Comment に Response モデル定義・OpenAPI スキーマ出力 |
 | v1.8.160 | FT282: platform — システム情報を露出しない（セキュリティ診断合格・情報漏洩防止） |
 | v1.8.159 | FT281: math — isclose / gcd / factorial（巨大整数 DoS ガード） |
 | v1.8.158 | FT280: re — ReDoS 対策（クラッカーペンテスト合格） |
@@ -141,7 +143,6 @@ FT282（platform — システム情報を露出しない）完了。**セキュ
 | 優先度 | Issue | タスク | 種別 |
 |---|---|---|---|
 | 高 | — | FT283 実施（gettext、診断・ペンテストなし） | FT |
-| 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | handler の response_model 統一 | enhancement |
 | 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | FT ループの目的・終着点を明文化 | docs |
 | 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | PyPI 公開フロー検証（uv publish） | enhancement |
 | 低 | — | PostgreSQL / MySQL 実 DB 統合テスト | infra |
@@ -153,7 +154,7 @@ FT282（platform — システム情報を露出しない）完了。**セキュ
 
 | 課題 | 優先度 | Issue | 備考 |
 |---|---|---|---|
-| handler response_model 未使用 | 中 | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | CLAUDE.md ポリシー違反 |
+| ~~handler response_model 未使用~~ | — | [#539](https://github.com/hideyukiMORI/nene2-python/issues/539) | ✅ 2026-05-29 解消（v1.8.161）。Note/Tag/Comment 全ハンドラーに `XxxResponse`/`XxxListResponse` を定義し `response_model` 明示。OpenAPI に 6 レスポンススキーマが出力されることを確認。466 tests 据え置き |
 | FT ループ目的の明文化 | 中 | [#540](https://github.com/hideyukiMORI/nene2-python/issues/540) | フェーズ変化の記録 |
 | PyPI 未公開 | 中 | [#541](https://github.com/hideyukiMORI/nene2-python/issues/541) | uv publish フロー検証が必要 |
 | ~~古い FT サンドボックス肥大化~~ | — | — | ✅ 2026-05-29 整理（5.1G→79M）。`ft-status.sh --clean-sandbox` を追加（.venv/キャッシュ削除・ソース保持・uv sync で再生可）。`--clean` は dist/ のみで誤記だった |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.160"
+version = "1.8.161"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/example/comment/handler.py
+++ b/src/example/comment/handler.py
@@ -4,13 +4,11 @@ Routes are nested under /notes/{note_id}/comments.
 """
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from nene2.http import PaginationQueryParser, PaginationResponse
+from nene2.http import PaginationQueryParser
 from nene2.validation.exceptions import ValidationError, ValidationException
 
-from .entity import Comment
 from .exceptions import CommentNotFoundException
 from .use_case import (
     CreateCommentInput,
@@ -34,8 +32,22 @@ class UpdateCommentBody(BaseModel):
     body: str = Field(max_length=5_000, description="Comment body.")
 
 
-def _comment_dict(comment: Comment) -> dict[str, object]:
-    return {"id": comment.id, "note_id": comment.note_id, "body": comment.body}
+class CommentResponse(BaseModel):
+    id: int = Field(description="Comment identifier.")
+    note_id: int = Field(description="Owning note identifier.")
+    body: str = Field(description="Comment body.")
+
+
+class CommentListResponse(BaseModel):
+    items: list[CommentResponse] = Field(description="Comments on this page.")
+    limit: int = Field(description="Page size.")
+    offset: int = Field(description="Page offset.")
+    total: int = Field(description="Total number of comments.")
+
+
+def _validate_comment_body(body: str) -> None:
+    if not body.strip():
+        raise ValidationException([ValidationError("body", "Body must not be empty.", "required")])
 
 
 def make_comment_router(
@@ -47,54 +59,44 @@ def make_comment_router(
 ) -> APIRouter:
     router = APIRouter(prefix="/notes/{note_id}/comments", tags=["comments"])
 
-    @router.get("")
-    async def list_comments(note_id: int, request: Request) -> JSONResponse:
+    @router.get("", response_model=CommentListResponse, summary="List comments")
+    async def list_comments(note_id: int, request: Request) -> CommentListResponse:
         pagination = PaginationQueryParser.parse(request)
         output = list_use_case.execute(
             ListCommentsInput(note_id=note_id, limit=pagination.limit, offset=pagination.offset)
         )
-        return JSONResponse(
-            PaginationResponse(
-                items=[_comment_dict(c) for c in output.items],
-                limit=output.limit,
-                offset=output.offset,
-                total=output.total,
-            ).to_dict()
+        return CommentListResponse(
+            items=[CommentResponse(id=c.id, note_id=c.note_id, body=c.body) for c in output.items],
+            limit=output.limit,
+            offset=output.offset,
+            total=output.total,
         )
 
-    @router.get("/{comment_id}")
-    async def get_comment(note_id: int, comment_id: int) -> JSONResponse:
+    @router.get("/{comment_id}", response_model=CommentResponse, summary="Get a comment")
+    async def get_comment(note_id: int, comment_id: int) -> CommentResponse:
         comment = get_use_case.execute(GetCommentInput(comment_id=comment_id))
         if comment.note_id != note_id:
             raise CommentNotFoundException(comment_id)
-        return JSONResponse(_comment_dict(comment))
+        return CommentResponse(id=comment.id, note_id=comment.note_id, body=comment.body)
 
-    @router.post("", status_code=201)
-    async def create_comment(note_id: int, body: CreateCommentBody) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.body.strip():
-            errors.append(ValidationError("body", "Body must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
+    @router.post("", status_code=201, response_model=CommentResponse, summary="Create a comment")
+    async def create_comment(note_id: int, body: CreateCommentBody) -> CommentResponse:
+        _validate_comment_body(body.body)
         comment = create_use_case.execute(CreateCommentInput(note_id=note_id, body=body.body))
-        return JSONResponse(_comment_dict(comment), status_code=201)
+        return CommentResponse(id=comment.id, note_id=comment.note_id, body=comment.body)
 
-    @router.put("/{comment_id}")
+    @router.put("/{comment_id}", response_model=CommentResponse, summary="Update a comment")
     async def update_comment(
         note_id: int, comment_id: int, body: UpdateCommentBody
-    ) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.body.strip():
-            errors.append(ValidationError("body", "Body must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
+    ) -> CommentResponse:
+        _validate_comment_body(body.body)
         existing = get_use_case.execute(GetCommentInput(comment_id=comment_id))
         if existing.note_id != note_id:
             raise CommentNotFoundException(comment_id)
         comment = update_use_case.execute(UpdateCommentInput(comment_id=comment_id, body=body.body))
-        return JSONResponse(_comment_dict(comment))
+        return CommentResponse(id=comment.id, note_id=comment.note_id, body=comment.body)
 
-    @router.delete("/{comment_id}", status_code=204)
+    @router.delete("/{comment_id}", status_code=204, summary="Delete a comment")
     async def delete_comment(note_id: int, comment_id: int) -> None:
         existing = get_use_case.execute(GetCommentInput(comment_id=comment_id))
         if existing.note_id != note_id:

--- a/src/example/note/handler.py
+++ b/src/example/note/handler.py
@@ -1,10 +1,9 @@
 """Note HTTP handlers — thin layer: parse → use-case → response."""
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from nene2.http import PaginationQueryParser, PaginationResponse
+from nene2.http import PaginationQueryParser
 from nene2.validation.exceptions import ValidationError, ValidationException
 
 from .use_case import (
@@ -31,6 +30,29 @@ class UpdateNoteBody(BaseModel):
     body: str = Field(max_length=10_000, description="Note body.")
 
 
+class NoteResponse(BaseModel):
+    id: int = Field(description="Note identifier.")
+    title: str = Field(description="Note title.")
+    body: str = Field(description="Note body.")
+
+
+class NoteListResponse(BaseModel):
+    items: list[NoteResponse] = Field(description="Notes on this page.")
+    limit: int = Field(description="Page size.")
+    offset: int = Field(description="Page offset.")
+    total: int = Field(description="Total number of notes.")
+
+
+def _validate_note_body(title: str, body: str) -> None:
+    errors: list[ValidationError] = []
+    if not title.strip():
+        errors.append(ValidationError("title", "Title must not be empty.", "required"))
+    if not body.strip():
+        errors.append(ValidationError("body", "Body must not be empty.", "required"))
+    if errors:
+        raise ValidationException(errors)
+
+
 def make_note_router(
     list_use_case: ListNotesUseCase,
     get_use_case: GetNoteUseCase,
@@ -40,53 +62,35 @@ def make_note_router(
 ) -> APIRouter:
     router = APIRouter(prefix="/notes", tags=["notes"])
 
-    @router.get("")
-    async def list_notes(request: Request) -> JSONResponse:
+    @router.get("", response_model=NoteListResponse, summary="List notes")
+    async def list_notes(request: Request) -> NoteListResponse:
         pagination = PaginationQueryParser.parse(request)
         output = list_use_case.execute(ListNotesInput(pagination.limit, pagination.offset))
-        return JSONResponse(
-            PaginationResponse(
-                items=[{"id": n.id, "title": n.title, "body": n.body} for n in output.items],
-                limit=output.limit,
-                offset=output.offset,
-                total=output.total,
-            ).to_dict()
+        return NoteListResponse(
+            items=[NoteResponse(id=n.id, title=n.title, body=n.body) for n in output.items],
+            limit=output.limit,
+            offset=output.offset,
+            total=output.total,
         )
 
-    @router.get("/{note_id}")
-    async def get_note(note_id: int) -> JSONResponse:
+    @router.get("/{note_id}", response_model=NoteResponse, summary="Get a note")
+    async def get_note(note_id: int) -> NoteResponse:
         note = get_use_case.execute(GetNoteInput(note_id))
-        return JSONResponse({"id": note.id, "title": note.title, "body": note.body})
+        return NoteResponse(id=note.id, title=note.title, body=note.body)
 
-    @router.post("", status_code=201)
-    async def create_note(body: CreateNoteBody) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.title.strip():
-            errors.append(ValidationError("title", "Title must not be empty.", "required"))
-        if not body.body.strip():
-            errors.append(ValidationError("body", "Body must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
-
+    @router.post("", status_code=201, response_model=NoteResponse, summary="Create a note")
+    async def create_note(body: CreateNoteBody) -> NoteResponse:
+        _validate_note_body(body.title, body.body)
         note = create_use_case.execute(CreateNoteInput(body.title, body.body))
-        return JSONResponse(
-            {"id": note.id, "title": note.title, "body": note.body}, status_code=201
-        )
+        return NoteResponse(id=note.id, title=note.title, body=note.body)
 
-    @router.put("/{note_id}")
-    async def update_note(note_id: int, body: UpdateNoteBody) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.title.strip():
-            errors.append(ValidationError("title", "Title must not be empty.", "required"))
-        if not body.body.strip():
-            errors.append(ValidationError("body", "Body must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
-
+    @router.put("/{note_id}", response_model=NoteResponse, summary="Update a note")
+    async def update_note(note_id: int, body: UpdateNoteBody) -> NoteResponse:
+        _validate_note_body(body.title, body.body)
         note = update_use_case.execute(UpdateNoteInput(note_id, body.title, body.body))
-        return JSONResponse({"id": note.id, "title": note.title, "body": note.body})
+        return NoteResponse(id=note.id, title=note.title, body=note.body)
 
-    @router.delete("/{note_id}", status_code=204)
+    @router.delete("/{note_id}", status_code=204, summary="Delete a note")
     async def delete_note(note_id: int) -> None:
         delete_use_case.execute(DeleteNoteInput(note_id))
 

--- a/src/example/tag/handler.py
+++ b/src/example/tag/handler.py
@@ -1,10 +1,9 @@
 """Tag HTTP handlers — thin layer: parse → use-case → response."""
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from nene2.http import PaginationQueryParser, PaginationResponse
+from nene2.http import PaginationQueryParser
 from nene2.validation.exceptions import ValidationError, ValidationException
 
 from .use_case import (
@@ -29,6 +28,23 @@ class UpdateTagBody(BaseModel):
     name: str = Field(max_length=200, description="Tag name.")
 
 
+class TagResponse(BaseModel):
+    id: int = Field(description="Tag identifier.")
+    name: str = Field(description="Tag name.")
+
+
+class TagListResponse(BaseModel):
+    items: list[TagResponse] = Field(description="Tags on this page.")
+    limit: int = Field(description="Page size.")
+    offset: int = Field(description="Page offset.")
+    total: int = Field(description="Total number of tags.")
+
+
+def _validate_tag_name(name: str) -> None:
+    if not name.strip():
+        raise ValidationException([ValidationError("name", "Name must not be empty.", "required")])
+
+
 def make_tag_router(
     list_use_case: ListTagsUseCase,
     get_use_case: GetTagUseCase,
@@ -38,47 +54,35 @@ def make_tag_router(
 ) -> APIRouter:
     router = APIRouter(prefix="/tags", tags=["tags"])
 
-    @router.get("")
-    async def list_tags(request: Request) -> JSONResponse:
+    @router.get("", response_model=TagListResponse, summary="List tags")
+    async def list_tags(request: Request) -> TagListResponse:
         pagination = PaginationQueryParser.parse(request)
         output = list_use_case.execute(ListTagsInput(pagination.limit, pagination.offset))
-        return JSONResponse(
-            PaginationResponse(
-                items=[{"id": t.id, "name": t.name} for t in output.items],
-                limit=output.limit,
-                offset=output.offset,
-                total=output.total,
-            ).to_dict()
+        return TagListResponse(
+            items=[TagResponse(id=t.id, name=t.name) for t in output.items],
+            limit=output.limit,
+            offset=output.offset,
+            total=output.total,
         )
 
-    @router.get("/{tag_id}")
-    async def get_tag(tag_id: int) -> JSONResponse:
+    @router.get("/{tag_id}", response_model=TagResponse, summary="Get a tag")
+    async def get_tag(tag_id: int) -> TagResponse:
         tag = get_use_case.execute(GetTagInput(tag_id))
-        return JSONResponse({"id": tag.id, "name": tag.name})
+        return TagResponse(id=tag.id, name=tag.name)
 
-    @router.post("", status_code=201)
-    async def create_tag(body: CreateTagBody) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.name.strip():
-            errors.append(ValidationError("name", "Name must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
-
+    @router.post("", status_code=201, response_model=TagResponse, summary="Create a tag")
+    async def create_tag(body: CreateTagBody) -> TagResponse:
+        _validate_tag_name(body.name)
         tag = create_use_case.execute(CreateTagInput(body.name))
-        return JSONResponse({"id": tag.id, "name": tag.name}, status_code=201)
+        return TagResponse(id=tag.id, name=tag.name)
 
-    @router.put("/{tag_id}")
-    async def update_tag(tag_id: int, body: UpdateTagBody) -> JSONResponse:
-        errors: list[ValidationError] = []
-        if not body.name.strip():
-            errors.append(ValidationError("name", "Name must not be empty.", "required"))
-        if errors:
-            raise ValidationException(errors)
-
+    @router.put("/{tag_id}", response_model=TagResponse, summary="Update a tag")
+    async def update_tag(tag_id: int, body: UpdateTagBody) -> TagResponse:
+        _validate_tag_name(body.name)
         tag = update_use_case.execute(UpdateTagInput(tag_id, body.name))
-        return JSONResponse({"id": tag.id, "name": tag.name})
+        return TagResponse(id=tag.id, name=tag.name)
 
-    @router.delete("/{tag_id}", status_code=204)
+    @router.delete("/{tag_id}", status_code=204, summary="Delete a tag")
     async def delete_tag(tag_id: int) -> None:
         delete_use_case.execute(DeleteTagInput(tag_id))
 

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.160"
+version = "1.8.161"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 背景
CLAUDE.md は「レスポンスモデルを `response_model` で明示（Any 返却禁止）」と規定するが、Note/Tag/Comment の全ハンドラーは `JSONResponse` を直返ししており OpenAPI にレスポンス型が出ていなかった（ポリシーとコードの乖離）。

## 対応
- 各ドメインに `XxxResponse` / `XxxListResponse`（Pydantic・各フィールド `description` 付き）を定義
- `@router.xxx(..., response_model=..., summary=...)` と戻り値型を明示、`JSONResponse` を排除
- バリデーションを `_validate_*` ヘルパーに抽出し「parse → use-case → response」の薄さを維持
- delete（204）は `-> None` のまま

## 検証
- **OpenAPI に 6 レスポンススキーマ**（Note/Tag/Comment × 単体/一覧）が出力、各ルートが `$ref` 参照することを確認
- `pytest`(466 passed) / `mypy --strict` / `ruff check` / `ruff format --check` / `pip-audit` 全通過、カバレッジ 93.5%
- レスポンス JSON 形状は不変（既存 HTTP テストがそのままグリーン）

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)