### PR TITLE
docs+test: 差別化（MCP × HTTP）を可視化・パリティ保証 (#751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.8.165] — 2026-05-29
+
+差別化（MCP × HTTP）の可視化と保証 (#751)。
+
+### Added
+- 実行可能なパリティテスト `tests/example/test_http_mcp_parity.py` — HTTP アプリと
+  MCP サーバーを同一 SQLite ストアに配線し、MCP で作成したノートが HTTP で読める／
+  その逆、を表明。同じ UseCase が両サーフェスを支えることをリグレッションで守る。
+- explanation ドキュメント [`one-usecase-two-surfaces.md`](docs/explanation/one-usecase-two-surfaces.md)（EN/JA）—
+  HTTP ハンドラーと MCP ツールが同じ `CreateNoteUseCase` を呼ぶ並列コードと、
+  **あえて共有しないもの**（薄い HTTP 層: Pydantic 検証・認証・ページネーション）を明記。
+- design-philosophy（EN/JA）・README からクロスリンク。
+
 ## [1.8.164] — 2026-05-29
 
 実データベース（PostgreSQL / MySQL）統合テストを追加し、マルチDB対応を実測で検証 (#747)。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Python reference framework implementing the [NENE2](https://github.com/hideyuk
 - **ruff** — lint and format in one tool (replaces flake8, isort, black, bandit)
 - **RFC 9457 Problem Details** — uniform error responses across all endpoints
 - **Bearer Token / API Key auth** — `LocalTokenVerifier`, `CompositeAuthMiddleware`, dev JWT helpers
-- **MCP support** — expose UseCases as AI agent tools via `LocalMcpServer`
+- **MCP support** — expose the *same* UseCases as AI agent tools via `LocalMcpServer` ([one UseCase, two surfaces](docs/explanation/one-usecase-two-surfaces.md))
 - **SQLAlchemy Core** — parameterised SQL without ORM overhead
 - **Security middleware** — CSP, rate limiting, request size limit, CORS via `setup_middlewares()`
 - **ETag / conditional requests** — `generate_etag()`, `check_not_modified()`, `check_precondition()`

--- a/docs/explanation/design-philosophy.md
+++ b/docs/explanation/design-philosophy.md
@@ -26,7 +26,7 @@ Security is a design constraint, not an afterthought:
 
 ### LLM Delivery Ready
 
-Because UseCases are independent of HTTP and database, they can be registered directly as MCP tools. `src/example/mcp.py` proves this — 15 tools, zero extra plumbing.
+Because UseCases are independent of HTTP and database, they can be registered directly as MCP tools. `src/example/mcp.py` proves this — 15 tools, zero extra plumbing. See [One UseCase, two surfaces (HTTP + MCP)](one-usecase-two-surfaces.md) for the side-by-side code and the parity test that guards it.
 
 ---
 

--- a/docs/explanation/one-usecase-two-surfaces.md
+++ b/docs/explanation/one-usecase-two-surfaces.md
@@ -1,0 +1,83 @@
+# One UseCase, two surfaces (HTTP + MCP)
+
+The headline NENE2 promise is **"LLM delivery ready"**: the same domain logic is
+delivered both as a JSON HTTP API for applications *and* as
+[MCP](https://modelcontextprotocol.io/) tools for LLM agents — written once, with
+no per-surface duplication. This page shows exactly how, in the reference app.
+
+## The shared core
+
+Domain logic lives in **UseCase** classes that know nothing about FastAPI or
+SQLAlchemy ([`src/example/note/use_case.py`](../../src/example/note/use_case.py)).
+Both surfaces construct the *same* UseCase and call `.execute()`:
+
+**HTTP** — [`src/example/note/handler.py`](../../src/example/note/handler.py):
+
+```python
+@router.post("", status_code=201, response_model=NoteResponse, summary="Create a note")
+async def create_note(body: CreateNoteBody) -> NoteResponse:
+    _validate_note_body(body.title, body.body)               # HTTP-boundary concern
+    note = create_use_case.execute(CreateNoteInput(title=body.title, body=body.body))
+    return NoteResponse(id=note.id, title=note.title, body=note.body)
+```
+
+**MCP** — [`src/example/mcp.py`](../../src/example/mcp.py):
+
+```python
+@server.tool("Create a new note.")
+def create_note(title: str, body: str) -> dict:
+    return asdict(note_create.execute(CreateNoteInput(title=title, body=body)))
+```
+
+Same `CreateNoteUseCase`, same `CreateNoteInput`, same repository — only the
+**edge** differs. The UseCase `Input`/`Output` DTOs *are* the contract for both
+surfaces; FastMCP derives the tool schema from the function signature, FastAPI
+derives the OpenAPI schema from the Pydantic body and `response_model`.
+
+## What this buys you
+
+- Write and test the domain **once**; deliver it to apps (HTTP) and to agents
+  (MCP) from the same code path.
+- A bug fixed in the UseCase is fixed on **both** surfaces simultaneously.
+- New domains are reachable by agents the moment their UseCases exist — `mcp.py`
+  wires 15 tools (Note / Tag / Comment) with no extra plumbing.
+
+## Proof (a test, not a claim)
+
+[`tests/example/test_http_mcp_parity.py`](../../tests/example/test_http_mcp_parity.py)
+wires an HTTP app and an MCP server onto the **same** SQLite store and asserts the
+surfaces are interchangeable:
+
+- a note created through the MCP `create_note` tool is readable through `GET /examples/notes/{id}`,
+- a note created through HTTP `POST /examples/notes` is readable through the MCP `get_note` tool,
+- both writes land in one store.
+
+This guards the differentiator as a regression test — if the two surfaces ever
+drift apart, CI fails.
+
+## What is deliberately *not* shared
+
+The **thin HTTP layer** keeps surface-specific concerns at the edge, out of the
+UseCase:
+
+| Concern | Where it lives | Shared with MCP? |
+|---|---|---|
+| Pydantic body validation, `max_length` | `CreateNoteBody` in `handler.py` | No |
+| Empty-field rejection | `_validate_note_body` in `handler.py` | No |
+| Authentication, CORS, throttling | middleware in `app.py` | No |
+| Pagination parsing, RFC 9457 errors | HTTP layer | No |
+| **Create / read / update / delete logic, not-found semantics** | **UseCase + entity** | **Yes** |
+
+This is the **API-first / thin-HTTP-layer** principle in action: the edge adapts
+each protocol, the center holds the domain. The practical rule for implementers:
+
+> If a rule must hold for **both** surfaces, put it in the UseCase or the entity —
+> not in the handler. Validation placed in the HTTP handler does **not** protect
+> the MCP tool.
+
+## See also
+
+- [Design philosophy → LLM Delivery Ready](design-philosophy.md)
+- [Architecture overview](architecture.md)
+- [ADR 0011 — MCP as a core dependency](../adr/0011-mcp-as-core-dependency.md)
+- [How to set up the MCP server](../howto/mcp-setup.md)

--- a/docs/ja/explanation/design-philosophy.md
+++ b/docs/ja/explanation/design-philosophy.md
@@ -26,7 +26,7 @@ HTTP Handler はビジネスロジックを持ちません。**parse → use-cas
 
 ### LLM Delivery Ready
 
-UseCase は HTTP・DB から独立しているため、MCP ツールとして直接再利用できます。`src/example/mcp.py` はその実証です。
+UseCase は HTTP・DB から独立しているため、MCP ツールとして直接再利用できます。`src/example/mcp.py` はその実証です。並べて見るコードと、それを守るパリティテストは [1 つの UseCase、2 つのサーフェス（HTTP + MCP）](one-usecase-two-surfaces.md) を参照してください。
 
 ## PHP NENE2 との対応表
 

--- a/docs/ja/explanation/one-usecase-two-surfaces.md
+++ b/docs/ja/explanation/one-usecase-two-surfaces.md
@@ -1,0 +1,82 @@
+# 1 つの UseCase、2 つのサーフェス（HTTP + MCP）
+
+NENE2 の看板である **「LLM delivery ready」** とは、同じドメインロジックを、アプリ
+向けの JSON HTTP API としても、LLM エージェント向けの
+[MCP](https://modelcontextprotocol.io/) ツールとしても提供できる——サーフェスごとに
+重複を書かず、一度書くだけ——という意味である。本ページはそれがリファレンスアプリで
+どう実現されているかを示す。
+
+## 共有される中核
+
+ドメインロジックは FastAPI も SQLAlchemy も知らない **UseCase** クラスに置かれる
+（[`src/example/note/use_case.py`](../../../src/example/note/use_case.py)）。両サーフェス
+は *同じ* UseCase を構築し `.execute()` を呼ぶ:
+
+**HTTP** — [`src/example/note/handler.py`](../../../src/example/note/handler.py):
+
+```python
+@router.post("", status_code=201, response_model=NoteResponse, summary="Create a note")
+async def create_note(body: CreateNoteBody) -> NoteResponse:
+    _validate_note_body(body.title, body.body)               # HTTP 境界の関心事
+    note = create_use_case.execute(CreateNoteInput(title=body.title, body=body.body))
+    return NoteResponse(id=note.id, title=note.title, body=note.body)
+```
+
+**MCP** — [`src/example/mcp.py`](../../../src/example/mcp.py):
+
+```python
+@server.tool("Create a new note.")
+def create_note(title: str, body: str) -> dict:
+    return asdict(note_create.execute(CreateNoteInput(title=title, body=body)))
+```
+
+同じ `CreateNoteUseCase`、同じ `CreateNoteInput`、同じリポジトリ——違うのは **端
+（edge）** だけ。UseCase の `Input`/`Output` DTO が両サーフェスの契約そのものであり、
+FastMCP は関数シグネチャからツールスキーマを、FastAPI は Pydantic ボディと
+`response_model` から OpenAPI スキーマを導出する。
+
+## これで得られるもの
+
+- ドメインを **一度だけ**書いてテストし、アプリ（HTTP）にもエージェント（MCP）にも
+  同じコードパスから届ける。
+- UseCase で直したバグは **両サーフェスで同時に**直る。
+- 新しいドメインは UseCase が存在した瞬間からエージェントに到達可能になる。`mcp.py`
+  は Note / Tag / Comment の 15 ツールを追加の配線なしで公開している。
+
+## 証明（主張ではなくテスト）
+
+[`tests/example/test_http_mcp_parity.py`](../../../tests/example/test_http_mcp_parity.py)
+は HTTP アプリと MCP サーバーを **同一** の SQLite ストアに配線し、両サーフェスが
+交換可能であることを表明する:
+
+- MCP の `create_note` ツールで作成したノートが `GET /examples/notes/{id}` で読める、
+- HTTP の `POST /examples/notes` で作成したノートが MCP の `get_note` ツールで読める、
+- どちらの書き込みも 1 つのストアに着地する。
+
+これにより差別化機能をリグレッションテストとして守る——両サーフェスが乖離すれば CI が
+落ちる。
+
+## あえて *共有しない* もの
+
+**薄い HTTP 層**は、サーフェス固有の関心事を UseCase の外、端に留める:
+
+| 関心事 | 置き場所 | MCP と共有？ |
+|---|---|---|
+| Pydantic ボディ検証・`max_length` | `handler.py` の `CreateNoteBody` | 否 |
+| 空フィールド拒否 | `handler.py` の `_validate_note_body` | 否 |
+| 認証・CORS・スロットリング | `app.py` のミドルウェア | 否 |
+| ページネーション解析・RFC 9457 エラー | HTTP 層 | 否 |
+| **作成/取得/更新/削除ロジック・not-found 意味論** | **UseCase + エンティティ** | **可** |
+
+これが **API-first / 薄い HTTP 層** の原則の実践である。端が各プロトコルに適合し、
+中核がドメインを保持する。実装者への実践的ルール:
+
+> **両**サーフェスで成り立つべきルールは、ハンドラーではなく UseCase かエンティティに
+> 置くこと。HTTP ハンドラーに置いた検証は MCP ツールを守らない。
+
+## 関連
+
+- [設計哲学 → LLM Delivery Ready](design-philosophy.md)
+- [アーキテクチャ概要](architecture.md)
+- [ADR 0011 — MCP をコア依存とする](../../adr/0011-mcp-as-core-dependency.md)
+- [MCP サーバーのセットアップ手順](../howto/mcp-setup.md)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,7 +1,7 @@
 # TODO — current
 
 最終更新: 2026-05-29
-現状: **v1.8.164 / 実DB統合テスト導入・マルチDB対応を実測検証 / CI グリーン**
+現状: **v1.8.165 / 差別化（MCP×HTTP）を可視化・パリティテストで保証 / CI グリーン**
 
 ---
 
@@ -44,6 +44,7 @@ v1.8.161）、#553（#578 で実装済みを確認し close）、ハウスキー
 
 | バージョン | 主な内容 |
 |---|---|
+| v1.8.165 | docs/test: 差別化（MCP×HTTP）可視化（#751）— 同一ストアでの HTTP↔MCP パリティテスト + explanation「one UseCase, two surfaces」（EN/JA）。共有する物（UseCase+永続化）/しない物（薄いHTTP層）を明記 |
 | v1.8.164 | feat: 実DB統合テスト（#747）— PostgreSQL/MySQL を CI service container で検証。psycopg2 lastrowid 非対応による INSERT 採番バグ（`save()` が常に id=1）を発見・修正。pymysql 追加 |
 | v1.8.163 | feat: PyPI 公開フロー検証（#541）— ビルド検証・CI package-build ジョブ・CHANGELOG 連携・リリース how-to |
 | v1.8.162 | docs: FT ループの目的・終着点を明文化（#540）— field-trial-methodology.md（EN/JA） |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nene2-python"
-version = "1.8.164"
+version = "1.8.165"
 description = "NENE2 Python — minimal API framework following NENE2's design philosophy"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/example/test_http_mcp_parity.py
+++ b/tests/example/test_http_mcp_parity.py
@@ -1,0 +1,77 @@
+"""Executable proof of the NENE2 differentiator: one UseCase, two surfaces.
+
+The same domain UseCase (`CreateNoteUseCase`, `GetNoteUseCase`, …) is what the HTTP
+handler calls *and* what the MCP tool calls — domain logic is written once and
+delivered over both surfaces. These tests wire an HTTP app and an MCP server onto
+the *same* SQLite database and assert the surfaces are interchangeable: write
+through one, read through the other.
+
+What is intentionally *not* shared is the HTTP boundary (Pydantic body validation,
+auth, pagination parsing) — that lives in the thin HTTP layer, not the UseCase.
+See docs/explanation/one-usecase-two-surfaces.md.
+"""
+
+import asyncio
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from example.app import create_app
+from example.mcp import create_mcp_server
+from nene2.config import AppSettings
+from nene2.mcp import LocalMcpServer
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> AppSettings:
+    # A real on-disk SQLite file so the HTTP app and the MCP server — each building
+    # its own engine — share one store, exactly as they would in production.
+    db_path = tmp_path / "parity.db"
+    return AppSettings(db_adapter="sqlite", db_name=str(db_path), throttle_enabled=False)
+
+
+@pytest.fixture
+def http(settings: AppSettings) -> Iterator[TestClient]:
+    with TestClient(create_app(settings)) as client:
+        yield client
+
+
+@pytest.fixture
+def mcp(settings: AppSettings) -> LocalMcpServer:
+    return create_mcp_server(settings)
+
+
+def _mcp_blocks(server: LocalMcpServer, name: str, arguments: dict[str, Any]) -> list[Any]:
+    # FastMCP returns one content block per returned item, so a list-returning tool
+    # yields several blocks. Parse them all; callers pick one or the whole list.
+    raw = asyncio.run(server._mcp.call_tool(name, arguments))  # noqa: SLF001
+    content = raw[0] if isinstance(raw, tuple) else raw
+    return [json.loads(block.text) for block in content]
+
+
+def _mcp_one(server: LocalMcpServer, name: str, arguments: dict[str, Any]) -> Any:
+    return _mcp_blocks(server, name, arguments)[0]
+
+
+def test_note_written_via_mcp_is_readable_via_http(http: TestClient, mcp: LocalMcpServer) -> None:
+    created = _mcp_one(mcp, "create_note", {"title": "from MCP", "body": "x"})
+    response = http.get(f"/examples/notes/{created['id']}")
+    assert response.status_code == 200
+    assert response.json()["title"] == "from MCP"
+
+
+def test_note_written_via_http_is_readable_via_mcp(http: TestClient, mcp: LocalMcpServer) -> None:
+    note_id = http.post("/examples/notes", json={"title": "from HTTP", "body": "y"}).json()["id"]
+    fetched = _mcp_one(mcp, "get_note", {"note_id": note_id})
+    assert fetched["title"] == "from HTTP"
+
+
+def test_both_surfaces_share_one_store(http: TestClient, mcp: LocalMcpServer) -> None:
+    _mcp_one(mcp, "create_note", {"title": "a", "body": "a"})
+    http.post("/examples/notes", json={"title": "b", "body": "b"})
+    listed = _mcp_blocks(mcp, "list_notes", {})
+    assert len(listed) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "nene2-python"
-version = "1.8.164"
+version = "1.8.165"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 概要

NENE2 の看板「LLM delivery ready」=**同じ UseCase を HTTP API と MCP ツールの両方で提供する**は、コードでは既に実現済み（`src/example/mcp.py` の 15 ツールが各 UseCase に委譲）。しかし**可視化も保証もされていなかった**。本 PR で両面を固める。

## 追加

### 実行可能な証明（主張ではなくテスト）
`tests/example/test_http_mcp_parity.py` — HTTP アプリと MCP サーバーを**同一 SQLite ストア**に配線し:
- MCP `create_note` で作成したノートが `GET /examples/notes/{id}` で読める
- HTTP `POST /examples/notes` で作成したノートが MCP `get_note` で読める
- どちらの書き込みも 1 ストアに着地する

両サーフェスが乖離すれば CI が落ちる = 差別化をリグレッションで守る。

### 可視化
`docs/explanation/one-usecase-two-surfaces.md`（EN/JA）— HTTP ハンドラーと MCP ツールが同じ `CreateNoteUseCase`／`CreateNoteInput` を呼ぶ並列コード、得られるもの、そして **あえて共有しないもの** を表で明記。

### 正確さ（誇張しない）
調査で判明した事実を反映: 入力検証は HTTP ハンドラー（Pydantic `Field(max_length)` + `_validate_note_body`）にあり UseCase には無い。→ **共有されるのはドメインロジック+永続化のみ**で、HTTP 境界の関心事（検証・認証・ページネーション）は薄い HTTP 層に留まる、という「thin HTTP layer」原則をそのまま説明。実装者向けルール「両サーフェスで成り立つべき規則は UseCase/エンティティに置く」も明記。

### 発見可能性
design-philosophy（EN/JA）の LLM Delivery Ready 節・README からクロスリンク。

## 検証

全ゲート通過: **469 passed / 9 skipped**（+3 パリティテスト）・coverage 93.16%・mypy・ruff・format。MCP ツールの end-to-end 実行も手元で確認済み。

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)