### PR TITLE
fix(docs): VitePress ビルド破損を修正しデプロイ復旧 + ナビ補完 (#755)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -52,6 +52,8 @@ function sidebarEn() {
         { text: 'Configure auth',                link: '/how-to/configure-auth' },
         { text: 'Set up MCP',                    link: '/howto/mcp-setup' },
         { text: 'Run tests',                     link: '/how-to/run-tests' },
+        { text: 'Run real-DB integration tests', link: '/how-to/run-integration-tests' },
+        { text: 'Release and publish to PyPI',   link: '/how-to/release-and-publish' },
       ],
     }],
     '/explanation/': [{
@@ -59,6 +61,8 @@ function sidebarEn() {
       items: [
         { text: 'Architecture',      link: '/explanation/architecture' },
         { text: 'Design philosophy', link: '/explanation/design-philosophy' },
+        { text: 'One UseCase, two surfaces (HTTP + MCP)', link: '/explanation/one-usecase-two-surfaces' },
+        { text: 'Field Trial methodology', link: '/explanation/field-trial-methodology' },
       ],
     }, {
       text: 'ADR',
@@ -110,11 +114,14 @@ function sidebarJa() {
     '/ja/how-to/': [{
       text: 'ハウツーガイド',
       items: [
+        { text: '新しいプロジェクトを始める',          link: '/ja/how-to/new-project' },
         { text: '新しいドメインを追加する',            link: '/ja/how-to/add-new-domain' },
         { text: 'SQLAlchemy リポジトリを実装する',    link: '/ja/how-to/sqlalchemy-repository' },
         { text: '認証を設定する',                     link: '/ja/how-to/configure-auth' },
         { text: 'MCP セットアップ',                   link: '/ja/howto/mcp-setup' },
         { text: 'テストを実行する',                   link: '/ja/how-to/run-tests' },
+        { text: '実DB統合テストの実行',               link: '/ja/how-to/run-integration-tests' },
+        { text: 'リリースと PyPI 公開',               link: '/ja/how-to/release-and-publish' },
       ],
     }],
     '/ja/explanation/': [{
@@ -122,6 +129,8 @@ function sidebarJa() {
       items: [
         { text: 'アーキテクチャ概要',        link: '/ja/explanation/architecture' },
         { text: '設計思想と PHP との対応',   link: '/ja/explanation/design-philosophy' },
+        { text: '1 つの UseCase、2 つのサーフェス（HTTP + MCP）', link: '/ja/explanation/one-usecase-two-surfaces' },
+        { text: 'フィールドトライアル方法論', link: '/ja/explanation/field-trial-methodology' },
       ],
     }],
     '/ja/reference/': [{

--- a/docs/field-trials/2026-05-field-trial-279.md
+++ b/docs/field-trials/2026-05-field-trial-279.md
@@ -63,7 +63,7 @@
 | XXE | `<!ENTITY x SYSTEM "file:///etc/passwd">` | **422**（実体宣言非サポート） |
 | 実体展開爆弾 | ネスト ENTITY | **422**（実体宣言非サポート） |
 | 深いネスト | 35 段 array | **422**（深さ上限） |
-| 不正データ | `not xml {{{` | **422**（syntax error） |
+| 不正データ | <code v-pre>not xml {{{</code> | **422**（syntax error） |
 | サイズ | 100k 超 | **422** |
 | セキュリティヘッダー | — | 付与あり |
 


### PR DESCRIPTION
## 概要

GitHub Pages（https://hideyukimori.github.io/nene2-python/）のデプロイ（`docs.yml`）が**直近4回連続で失敗**し、公開サイトが古いままだった。原因を特定し復旧する。

## 原因と修正

VitePress(Vue) が Markdown の `{{` を補間構文と解釈する。FT279 表セルの**三連括弧 `{{{`**（`not xml {{{`）が閉じ `}}` を探してファイル末尾まで走りパースエラー → ビルド全停止。`<code v-pre>` でラップして解消。

- 二連 `{{`（インラインコード内）は VitePress が正しくエスケープ → 安全（変更不要）
- Jinja `{%...%}`（template.md）はフェンス済みコードブロック内 → 安全
- 壊すのは `{{{` のみと実測で確認

## ナビ補完

サイドバー（`.vitepress/config.mts`）の手動定義に未掲載だったページを EN/JA に追加（field-trial-methodology / one-usecase-two-surfaces / run-integration-tests / release-and-publish、JA は new-project も）。

## 検証

`npm run docs:build` → **exit 0**、追加ページの HTML 出力を確認。マージで `docs.yml` のデプロイが復旧する見込み。

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)