### PR TITLE
feat(docs): カスタムドメイン docs.nene2-python.dev で配信 (#763)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -211,7 +211,8 @@ function sidebarJa() {
 export default defineConfig({
   title: 'NENE2 Python',
   description: 'FastAPI + Clean Architecture + MCP. Python 3.12+. AI-ready from day one.',
-  base: process.env.GITHUB_ACTIONS ? '/nene2-python/' : '/',
+  // Served at the root of the custom domain docs.nene2-python.dev (see docs/public/CNAME).
+  base: '/',
   srcDir: './docs',
   outDir: './.vitepress/dist',
   cleanUrls: true,

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.nene2-python.dev


### PR DESCRIPTION
## 概要

nene2-python 専用ドメイン `nene2-python.dev` を取得し、docs を `docs.nene2-python.dev` で配信する。

## 変更
- VitePress `base` を `/nene2-python/` → `/`（カスタムドメイン直下配信）
- `docs/public/CNAME` に `docs.nene2-python.dev`（ビルド成果物ルートに出力 → Pages がカスタムドメイン設定）

## 状態
- DNS: `CNAME docs → hideyukimori.github.io` 設定・反映確認済み
- ローカルビルド: exit 0、`dist/CNAME` 出力確認、アセットが `/assets/...`（base `/`）

## マージ後
docs.yml デプロイ → `https://docs.nene2-python.dev/` 配信。HTTPS 証明書プロビジョニング後に Enforce HTTPS。旧 github.io は自動リダイレクト。`.com` はレジストラ転送（別途）。

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)