### PR TITLE
chore(deps): bump nanoid to 3.3.18 in lockfile (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,9 +1996,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Closes GHSA-2v37-7h3g-55p8 (nanoid HIGH, infinite loop when `size=0`; patch floor 3.3.17) by bumping `nanoid` 3.3.12 → 3.3.18 in `package-lock.json` only.
- Root JS lockfile here is docs tooling only (`nene2-python-docs`, single devDependency `vitepress` for `docs:dev`/`docs:build`/`docs:preview`). No prod dependency ships nanoid.
- Measured route (not assumed): `vitepress@1.6.4 -> postcss@8.5.15 -> nanoid@3.3.12`, lockfile node has `"dev": true` throughout.
- `npm update nanoid --package-lock-only` (no `--force`) resolved to 3.3.18 within postcss's existing `^3.3.12` range. `package.json` untouched.

## Background
The 08-09 fleet-wide dependency census only counted product ships and missed the nene2-* tooling repos (scope miss). hub re-scanned the full fleet on 08-12 and found this repo's root `package-lock.json` untouched since the last commit (2026-05-30) with the vulnerable nanoid still present. This PR closes that specific gap.

## Advisory inventory (report only — not fixed in this PR)
Remaining high/critical advisories after this bump, per `npm audit --package-lock-only`:

| package | GHSA | route (parent) | dev/prod | fixAvailable | lockfile-only closeable? |
|---|---|---|---|---|---|
| postcss@8.5.15 | GHSA-r28c-9q8g-f849 (high) + GHSA-fxqj-rqcc-2cmp (moderate, same package) | vitepress → postcss (also via vite, @vue/compiler-sfc, deduped) | dev | `true` | Likely yes — `npm audit fix --package-lock-only --dry-run` reports a fix available without touching package.json; needs an actual (non-dry-run) attempt + audit re-check to confirm, so left for a follow-up PR. |
| vite@5.4.21 (via esbuild) | GHSA-4w7w-66w2-5vf9, GHSA-v6wh-96g9-6wx3, GHSA-67mh-4wv8-2f99 (esbuild dep, moderate) | vitepress → vite → esbuild | dev | `false` | No — no fix available in-range; would require a vitepress major bump (out of scope for a lockfile-only patch). |
| vitepress@1.6.4 | (inherits vite's) | direct devDependency | dev | `false` | No — same reason as vite. |

Only nanoid is touched in this PR. The rest is surfaced for the board so hide can decide whether a vitepress major-version bump is worth scheduling.

## Test plan
- [x] `git diff --name-only` on the branch shows only `package-lock.json` changed
- [x] `npm audit --package-lock-only --audit-level=high` no longer reports the nanoid advisory
- [x] `package.json` has no diff (no scripts named exactly `test`/`lint`/`build` exist in this docs-only package.json — closest is `docs:build`, not run since node_modules itself wasn't reinstalled for this lockfile-only change)
- [ ] CI green

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>