### PR TITLE
fix(ci): notify-failure の重複判定を jq 実体に渡すよう修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,9 @@ jobs:
           set -euo pipefail
           # 完全一致でタイトルを探す。GitHub の検索インデックスは反映が遅れることがあるため、
           # `--search` ではなく取得後の完全一致で判定する（配布時に 19 艦で挙動が揺れないように）。
+          # `gh --jq` は `--arg` を受け付けない（あれは jq CLI のフラグ）ので、実体の jq へ渡す。
           existing="$(gh issue list --state open --limit 100 --json number,title \
-            --jq --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
 
           body="週次の \`schedule\` 実行が失敗しました。
 


### PR DESCRIPTION
PR #773 で入れた `notify-failure` を `simulate_failure=true` で実際に発火させたところ、**ジョブ自体が失敗**しました（[run 31574066871](https://github.com/hideyukiMORI/nene2-python/actions/runs/31574066871)）。

```
Usage:  gh issue list [flags]
  -q, --jq expression      Filter JSON output using a jq expression
##[error]Process completed with exit code 1.
```

## 原因

`gh` の `--jq` は **`--arg` を受け付けません**。`--arg` は `jq` CLI 側のフラグです。

```bash
# ❌ gh --jq に --arg を渡していた
gh issue list --json number,title --jq --arg t "$ISSUE_TITLE" '...'

# ✅ 実体の jq へパイプして --arg を渡す
gh issue list --json number,title | jq -r --arg t "$ISSUE_TITLE" '...'
```

**権限の問題ではありませんでした** — `permissions: issues: write` が効くかどうかの検証まで到達していませんでした。それは次の発火で測ります。

## 検証

jq 式が一致時に番号・不一致時に空文字を返すことをローカルで確認:

```
$ echo '[{"number":5,"title":"🔴 週次 CI（schedule）が失敗しています"},...]' \
  | jq -r --arg t '🔴 週次 CI（schedule）が失敗しています' 'map(select(.title == $t)) | .[0].number // empty'
5
$ echo '[{"number":9,"title":"別件"}]' | jq -r --arg t '...' '...'
（空）
```

## この不具合が示していること

**`simulate_failure` の踏み台を用意した意味がそのまま出ました。** これを置いていなければ、この不具合は**月曜の週次実行が初めて失敗したとき**に露見していました。しかも「Issue が立たない」という形で露見するので、**失敗そのものに誰も気づかないまま**です。

「置いた ≠ 動いた」を分ける装置が無いと、通知装置の故障は通知されません。フリートへ配る前に 1 艦で実測する方針が正しかったということでもあります。

## マージ後に続けて実測すること

1. `simulate_failure=true` 1 回目 → Issue が**新規起票**されるか（＝ `permissions: issues: write` が `default_workflow_permissions: read` の下で効くか）
2. `simulate_failure=true` 2 回目 → **同じ Issue に追記**されるか（＝ Issue が 2 本立たないか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)