### PR TITLE
fix(ci): notify-failure に GH_REPO を渡す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,10 @@ jobs:
     env:
       ISSUE_TITLE: '🔴 週次 CI（schedule）が失敗しています'
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # このジョブは意図的に checkout しない（コードを見る必要がないので速い）。
+      # そのぶん `gh` が git remote からリポジトリを特定できないため、明示的に渡す。
+      # これが無いと `failed to run git: fatal: not a git repository` で落ちる（実測）。
+      GH_REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Create or update the failure issue


### PR DESCRIPTION
PR #774 の修正後、再度 `simulate_failure=true` で発火させたところ**別の原因で失敗**しました（[run 31574338749](https://github.com/hideyukiMORI/nene2-python/actions/runs/31574338749)）。

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## 原因

`notify-failure` は**意図的に `actions/checkout` をしていません**（コードを見る必要がないので速い）。そのぶん `gh` が git remote からリポジトリを特定できず、`gh issue list` がリポジトリ未確定で落ちていました。

`checkout` を足すのではなく **`GH_REPO` を明示的に渡して**解決しました。転記先の艦でも同じ形で効きます。

```yaml
env:
  GH_REPO: ${{ github.repository }}
```

## この 2 つ目の不具合が示していること

1 つ目（`gh --jq` に `--arg`）を直した時点では、**まだ本当に起票できるかは分かっていませんでした**。「直した」と「動いた」も別です。

`simulate_failure` の踏み台がなければ、この 2 つはどちらも**月曜の週次実行が初めて失敗したとき**にまとめて露見し、しかも「Issue が立たない」という形なので**失敗そのものに誰も気づかない**ままでした。フリートへ配る前に 1 艦で実測する方針の価値がここに出ています。

## まだ確認できていないこと

`permissions: issues: write` が `default_workflow_permissions: read` の下で実際に効くかは、**まだ到達していません**。次の発火で測ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)