### PR TITLE
chore(deps): postcss 8.5.15→8.5.26（lockfile only・high 2→1・#777）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,9 +2041,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2061,7 +2061,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Closes #777

`npm audit fix --package-lock-only`（**`--force` なし**）で閉じる分だけ。

## 変更（判例44 の4点・全数）

| 項目 | 値 |
| --- | --- |
| ① `packages` 件数 | **174 → 174（不変）** |
| ② 動いたエントリ | **1件のみ**: `postcss` **8.5.15 → 8.5.26**（**↑昇格**・降格0・追加0・消失0） |
| ③ workspaces / 複数 lockfile | `workspaces` **なし**・lockfile は **1本のみ** |
| ④ `package.json` | **無変更** |

## ゲートの実測

| | before | after |
| --- | --- | --- |
| `npm audit` | high **2** / moderate 2 / total 4 | high **1** / moderate 2 / total 3 |
| 名前 | esbuild / **postcss** / vite / vitepress | esbuild / vite / vitepress |

## 🔴 射程外（隠さず書きます）

残る `vitepress` → `vite`(high) → `esbuild` の鎖は **`package.json` の変更が要る**ので触りません。
この鎖は **nene2-python / nene-mcp / NENE2(root) / nene2-js の4リポで同一**なので、**1回の判断で4リポ片づく**性質のものです。
**版の向きを全数開示した材料**にしてから施主判断へ上げる段取り（hub GO 済み）。

## 併せて確認（board の記述が現況と合わない2点）

- 🟢 **nanoid は閉じている**: `origin/main` の lockfile 直読みで **3.3.18**〔実測〕・PR #767 は **MERGED**
- 🟢 **CI は緑**: `main` の push 契機の run は **success**（直近の failure は `simulate_failure=true` の意図的な故障注入）

---
⚠️ マージは施主／hub の手番です。実施は fleet-tooling（hub 発令 2026-08-15）。
